### PR TITLE
Allow artifact proxying in ML Flow

### DIFF
--- a/infra/role.tf
+++ b/infra/role.tf
@@ -13,12 +13,27 @@ resource "aws_iam_role" "app_role" {
       },
     ]
   })
+  inline_policy {
+    name = "allow_s3_access"
+
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect   = "Allow"
+          Action   = ["s3:*Object"]
+          Resource = ["arn:aws:s3:::${aws_s3_bucket.artifacts.bucket}/*"]
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["s3:ListBucket"]
+          Resource = ["arn:aws:s3:::${aws_s3_bucket.artifacts.bucket}"]
+        },
+      ]
+    })
+  }
 }
 
-resource "aws_iam_role_policy_attachment" "ecs_execution" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-  role       = aws_iam_role.app_role.name
-}
 
 # assigns the app policy
 resource "aws_iam_role_policy" "app_policy" {


### PR DESCRIPTION
Description:

Bumps MLFlow backend from 1.22 to 1.24. That's the latest labeled version I saw from getindata. Crucially, the ability to proxy model uploads was added in 1.23. (So users don't need permissions to hit our artifact bucket.) Also adds some permissions to the app role needed to write to S3. I had confused task roles and task execution roles in the earlier attempt.


While I was here, I gave upgrading to 2.x a more earnest try with the official MLFlow image. I didn't get that working but I'll record some lessons learned in #7