### PR TITLE
Allowlist binary content-type header

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Fixes # (Some reference to an issue)
+Link to any related issues, companion PRs, or blockers. eg, `Fixes #37`
 
 ## Overview
 
@@ -6,7 +6,7 @@ A quick summary of what this PR is meant to do.
 
 ## Discussion
 
-More context that you think is important for reviewers or our future selves looking at this PR.
+Any additional context that you think is important for reviewers or future users/contributors looking at this PR.
 
 ## Testing
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -153,6 +153,7 @@ resource "aws_api_gateway_deployment" "garden_deployment" {
     #       resources will show a difference after the initial implementation.
     #       It will stabilize to only change when resources change afterwards.
     redeployment = sha1(jsonencode([
+      aws_api_gateway_rest_api.garden_api,
       aws_api_gateway_resource.garden_app.id,
       aws_api_gateway_method.garden_auth_hookup.id,
       aws_api_gateway_integration.garden_app.id,

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -100,7 +100,8 @@ resource "aws_cloudwatch_log_group" "garden_app" {
 /* API Gateway */
 
 resource "aws_api_gateway_rest_api" "garden_api" {
-  name          = "garden_gateway"
+  name               = "garden_gateway"
+  binary_media_types = ["application/octet-stream"]
 }
 
 resource "aws_api_gateway_stage" "garden_api" {


### PR DESCRIPTION
Addresses #11. Sibling PR with https://github.com/Garden-AI/garden/pull/80

## Overview

Tell our API Gateway that it can let requests with the Content-Type application/octet-stream pass through without getting coerced to UTF-8.

## Discussion

Unlike the garden SDK PR, this one isn't a temporary fix. We want to allowlist this content type for good (and maybe more content types in the future, like images).

I also pulled over the revised PR guidelines from the other repo while I was here.

## Testing

Tested with the code in https://github.com/Garden-AI/garden/pull/80. I applied the Terraform changes, ran the SDK code that adds the content-type header, and confirmed we get an unmangled model.