### PR TITLE
Correct license copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Garden
+Copyright (c) 2023 University of Chicago
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Related to https://github.com/Garden-AI/garden/issues/55

## Overview

I used GitHub's license adding feature to make an MIT license at creation time. It attributed copyright to "Garden" but really it should be UChicago.

## Discussion

This is a sibling PR to https://github.com/Garden-AI/garden/pull/82. We should have both repos under the same license.
