### PR TITLE
Use 2.2.2 version of MLFlow backend. Add Dockerfile and instructions for publishing new version

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_task_definition" "mlflow" {
   container_definitions = jsonencode(concat([
     {
       name      = "mlflow"
-      image     = "gcr.io/getindata-images-public/mlflow:1.24.0"
+      image     = "public.ecr.aws/x2v7f8j4/mlflow:2.2.2"
       essential = true
 
       entryPoint = ["sh", "-c"]

--- a/mlflow-container/Dockerfile
+++ b/mlflow-container/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.8.13-slim
+
+# required by mysqclient
+RUN apt-get update -y && \
+    apt-get install -y python3-dev default-libmysqlclient-dev build-essential
+
+RUN pip install PyMySQL==0.10.1 mysqlclient==2.0.3 && \
+    pip install psycopg2-binary==2.8.6 && \
+    pip install mlflow[extras]==2.2.2
+
+ENV BACKEND_STORE_URI=
+ENV DEFAULT_ARTIFACT_ROOT=/opt/artifact
+
+EXPOSE 80
+
+CMD ["sh", "-c", "mlflow server --host 0.0.0.0 --port 80 --gunicorn-opts \"$GUNICORN_OPTS\" --backend-store-uri $BACKEND_STORE_URI --artifacts-destination $ARTIFACTS_DESTINATION --serve-artifacts"]

--- a/mlflow-container/README.md
+++ b/mlflow-container/README.md
@@ -1,0 +1,9 @@
+This container has been built one-off from a Garden dev's machine and pushed to a public AWS ECR repo.
+
+Below are the commands to tweak and run to publish a new version.
+
+```
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/x2v7f8j4
+docker build . --platform linux/amd64 -t public.ecr.aws/x2v7f8j4/mlflow:[version]
+docker push public.ecr.aws/x2v7f8j4/mlflow:[version]
+```


### PR DESCRIPTION
Resolves #7 

## Overview

This PR makes our ECS MLFlow cluster run on top of MLFlow 2.2.2 instead of 1.x. It also includes a Dockerfile and instructions for building and pushing a new version of the Docker image we need.

## Discussion

Building and pushing the Docker image was done in a non-automated way from my machine. We have an open ticket for automating this. (https://github.com/Garden-AI/garden/issues/91)

## Testing

After the ECS deploy was finished I ran the `test_mlflow_register` integration test to make sure the MLFlow round trip was still working.