### PR TITLE
Add route for updating record on Datacite

### DIFF
--- a/app/doi.py
+++ b/app/doi.py
@@ -58,7 +58,7 @@ def call_datacite(event, _context, _kwargs):
         # DataCite successful response *would* have all our repo info,
         # so extract just the newly minted DOI for the response body
         if method == "POST":
-            return return_response.update(
+            return_response.update(
                 {
                     "body": json.dumps(
                         {
@@ -67,5 +67,4 @@ def call_datacite(event, _context, _kwargs):
                     )
                 }
             )
-        else:
-            return return_response
+        return return_response

--- a/app/doi.py
+++ b/app/doi.py
@@ -95,4 +95,4 @@ def update_metadata(event, _context, _kwargs):
     else:
         # DataCite successful response *would* have all our repo info,
         # so extract just the newly minted DOI for the response body
-        return {"statusCode": 201}
+        return {"statusCode": 200}

--- a/app/doi.py
+++ b/app/doi.py
@@ -9,7 +9,8 @@ import logging
 logger = logging.getLogger()
 
 
-def mint_doi(event, _context, _kwargs):
+def call_datacite(event, _context, _kwargs):
+    method = event["httpMethod"]
     payload = json.loads(event["body"])
     try:
         DATACITE_REPOSITORY_ID = os.environ["DATACITE_REPOSITORY_ID"]
@@ -30,7 +31,16 @@ def mint_doi(event, _context, _kwargs):
     try:
         payload["data"]["attributes"]["prefix"] = DATACITE_PREFIX
 
-        res: requests.Response = requests.post(
+        if method == "POST":
+            request = requests.post
+            return_response = {"statusCode": 201}
+        elif method == "PUT":
+            request = requests.put
+            return_response = {"statusCode": 200}
+        else:
+            return {"statusCode": 400, "body": "Invalid request method."}
+
+        res: requests.Response = request(
             DATACITE_ENDPOINT,
             headers={"Content-Type": "application/vnd.api+json"},
             json=payload,
@@ -47,52 +57,15 @@ def mint_doi(event, _context, _kwargs):
     else:
         # DataCite successful response *would* have all our repo info,
         # so extract just the newly minted DOI for the response body
-        return {
-            "statusCode": 201,
-            "body": json.dumps(
+        if method == "POST":
+            return return_response.update(
                 {
-                    "doi": res.json()["data"]["attributes"]["doi"],
+                    "body": json.dumps(
+                        {
+                            "doi": res.json()["data"]["attributes"]["doi"],
+                        }
+                    )
                 }
-            ),
-        }
-
-
-def update_metadata(event, _context, _kwargs):
-    payload = json.loads(event["body"])
-    try:
-        DATACITE_REPOSITORY_ID = os.environ["DATACITE_REPOSITORY_ID"]
-        DATACITE_PASSWORD = os.environ["DATACITE_PASSWORD"]
-        DATACITE_ENDPOINT = os.environ["DATACITE_ENDPOINT"]
-        DATACITE_PREFIX = os.environ["DATACITE_PREFIX"]
-    except KeyError as e:
-        message = (
-            "Garden server was unable to authenticate with DataCite. Please "
-            "contact support and/or open an issue at "
-            "https://github.com/Garden-AI/garden-backend/issues. "
-        )
-        logger.error(f"DATACITE_* environment variables not set. env: {os.environ}")
-        return {
-            "statusCode": 500,
-            "body": json.dumps({"message": message, "error": str(e)}),
-        }
-    try:
-        payload["data"]["attributes"]["prefix"] = DATACITE_PREFIX
-
-        res: requests.Response = requests.put(
-            DATACITE_ENDPOINT,
-            headers={"Content-Type": "application/vnd.api+json"},
-            json=payload,
-            auth=(DATACITE_REPOSITORY_ID, DATACITE_PASSWORD),
-        )
-        res.raise_for_status()
-    except KeyError as e:
-        # failed to set prefix due to malformed payload
-        return {"statusCode": 400, "body": str(e)}
-    except HTTPError as e:
-        # DataCite error responses seem safe to include outright
-        # propagate errors from requests.raise_for_status directly
-        return {"statusCode": 500, "body": str(e)}
-    else:
-        # DataCite successful response *would* have all our repo info,
-        # so extract just the newly minted DOI for the response body
-        return {"statusCode": 200}
+            )
+        else:
+            return return_response

--- a/app/doi.py
+++ b/app/doi.py
@@ -55,3 +55,44 @@ def mint_doi(event, _context, _kwargs):
                 }
             ),
         }
+
+
+def update_metadata(event, _context, _kwargs):
+    payload = json.loads(event["body"])
+    try:
+        DATACITE_REPOSITORY_ID = os.environ["DATACITE_REPOSITORY_ID"]
+        DATACITE_PASSWORD = os.environ["DATACITE_PASSWORD"]
+        DATACITE_ENDPOINT = os.environ["DATACITE_ENDPOINT"]
+        DATACITE_PREFIX = os.environ["DATACITE_PREFIX"]
+    except KeyError as e:
+        message = (
+            "Garden server was unable to authenticate with DataCite. Please "
+            "contact support and/or open an issue at "
+            "https://github.com/Garden-AI/garden-backend/issues. "
+        )
+        logger.error(f"DATACITE_* environment variables not set. env: {os.environ}")
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"message": message, "error": str(e)}),
+        }
+    try:
+        payload["data"]["attributes"]["prefix"] = DATACITE_PREFIX
+
+        res: requests.Response = requests.put(
+            DATACITE_ENDPOINT,
+            headers={"Content-Type": "application/vnd.api+json"},
+            json=payload,
+            auth=(DATACITE_REPOSITORY_ID, DATACITE_PASSWORD),
+        )
+        res.raise_for_status()
+    except KeyError as e:
+        # failed to set prefix due to malformed payload
+        return {"statusCode": 400, "body": str(e)}
+    except HTTPError as e:
+        # DataCite error responses seem safe to include outright
+        # propagate errors from requests.raise_for_status directly
+        return {"statusCode": 500, "body": str(e)}
+    else:
+        # DataCite successful response *would* have all our repo info,
+        # so extract just the newly minted DOI for the response body
+        return {"statusCode": 201}

--- a/app/lambda_function.py
+++ b/app/lambda_function.py
@@ -23,4 +23,4 @@ def hello(event, context, kwargs):
 
 
 app.route("/doi", methods=["POST"])(mint_doi)  # equivalent to decorator syntax
-app.route("/doi", methods=["PATCH"])(update_metadata)
+app.route("/doi", methods=["PUT"])(update_metadata)

--- a/app/lambda_function.py
+++ b/app/lambda_function.py
@@ -1,6 +1,6 @@
 import json
 
-from doi import mint_doi
+from doi import mint_doi, update_metadata
 from tiny_router import TinyLambdaRouter
 
 app = TinyLambdaRouter()
@@ -23,3 +23,4 @@ def hello(event, context, kwargs):
 
 
 app.route("/doi", methods=["POST"])(mint_doi)  # equivalent to decorator syntax
+app.route("/doi", methods=["PATCH"])(update_metadata)

--- a/app/lambda_function.py
+++ b/app/lambda_function.py
@@ -1,6 +1,6 @@
 import json
 
-from doi import mint_doi, update_metadata
+from doi import call_datacite
 from tiny_router import TinyLambdaRouter
 
 app = TinyLambdaRouter()
@@ -22,5 +22,4 @@ def hello(event, context, kwargs):
     }
 
 
-app.route("/doi", methods=["POST"])(mint_doi)  # equivalent to decorator syntax
-app.route("/doi", methods=["PUT"])(update_metadata)
+app.route("/doi", methods=["POST", "PUT"])(call_datacite)  # equivalent to decorator syntax


### PR DESCRIPTION
Component of [#140](https://github.com/Garden-AI/garden/issues/140)

## Overview

Adds a route to the Garden backend for making PUT requests to Datacite.

## Testing

TBD.
