### PR TITLE
Fix urllib3 <-> boto incompatibility in authorizer Lambda

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.28.2
+urllib3<2

--- a/authorizer/requirements.txt
+++ b/authorizer/requirements.txt
@@ -1,1 +1,2 @@
 globus-sdk==3.1.0
+urllib3<2


### PR DESCRIPTION
When an automated backend build went out today, all requests to our API started failing even though no code had changed. So what did change? urllib3 recently graduated to 2.x, that was included in our dependencies bundle, and urllib3 2.x is incompatible with the version of boto that AWS bundles in to Lambda functions automatically. This is a hotfix but I'll cut a ticket for a more considered fix and monitoring.

The telltale log statement:

```

[ERROR] Runtime.ImportModuleError: Unable to import module 'lambda_function': cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_' (/var/task/urllib3/util/ssl_.py)Traceback (most recent call last): | [ERROR] Runtime.ImportModuleError: Unable to import module 'lambda_function': cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_' (/var/task/urllib3/util/ssl_.py) Traceback (most recent call last):
-- | --

```

## Testing

I did a sanity check that pip install should work. Now I'm gonna YOLO to prod and see if this fixes the issue.
