### PR TITLE
limit wait time to one second

### DIFF
--- a/app/search_record.py
+++ b/app/search_record.py
@@ -54,7 +54,7 @@ def publish(event, _context, _kwargs):
 
     publish_result = search_client.create_entry(GARDEN_INDEX_UUID, gmeta_ingest)
 
-    max_intervals = 30
+    max_intervals = 5
     task_result = search_client.get_task(publish_result["task_id"])
     while task_result["state"] not in {"FAILED", "SUCCESS"}:
         if not max_intervals:
@@ -66,7 +66,7 @@ def publish(event, _context, _kwargs):
                     }
                 ),
             }
-        sleep(2)
+        sleep(0.2)
         max_intervals -= 1
         task_result = search_client.get_task(publish_result["task_id"])
 

--- a/app/search_record.py
+++ b/app/search_record.py
@@ -48,7 +48,7 @@ def publish(event, _context, _kwargs):
         "subject": garden_meta[
             "uuid"
         ],  # needs to be updated to doi after #140 goes through
-        "visible_to": ["all_authenticated_users"],
+        "visible_to": ["public"],
         "content": garden_meta,
     }
 


### PR DESCRIPTION
## Overview

Reduce the time spent waiting for task response to dodge AWS enforced timeout.

## Testing

I recreated the script the server will run locally and ran it, receiving the equivalent of a 200 response.
