### PR TITLE
Make app lambda timeout 10 seconds instead of 3

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -80,6 +80,7 @@ resource "aws_lambda_function" "garden_app" {
   handler = "lambda_function.lambda_handler"
 
   role = aws_iam_role.lambda_exec.arn
+  timeout = 10
 
   environment {
     variables = {


### PR DESCRIPTION
Related to #15

## Overview

We were getting timeouts on search ingest with the Terraform default 3 second cap. This bumps it to 10.

## Testing

Already bumped to 10 in the console. This just enshrines the change.