### PR TITLE
align with the SDK and use doi subjects

### DIFF
--- a/app/search_record.py
+++ b/app/search_record.py
@@ -45,9 +45,7 @@ def publish(event, _context, _kwargs):
     garden_meta = json.loads(event["body"])
 
     gmeta_ingest = {
-        "subject": garden_meta[
-            "uuid"
-        ],  # needs to be updated to doi after #140 goes through
+        "subject": garden_meta["doi"],
         "visible_to": ["public"],
         "content": garden_meta,
     }


### PR DESCRIPTION
## Overview

When the SDK switches to expecting DOI subjects, the publish route needs to accommodate. This is that fix.

## Testing

Full testing can be performed prior to merge after updates to the SDK.