### PR TITLE
rename main to prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: deploy
 on:
   push:
     branches:
-      - main
+      - prod
       - dev
   workflow_dispatch:
 permissions:
@@ -33,7 +33,7 @@ jobs:
     - name: Set Environment
       id: vars
       run: |
-        if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+        if [[ "${{ github.ref }}" == "refs/heads/prod" ]]; then
           echo "::set-output name=env::prod"
         else
           echo "::set-output name=env::dev"

--- a/README.md
+++ b/README.md
@@ -10,4 +10,12 @@ The API is currently hosted on AWS Lambdas behind AWS API Gateway. Terraform to 
 
 `app` holds the code for our application Lambda, deployed at the `/` route. It assumes the user is logged in and does its own internal routing such that we do not need to deploy new Lambdas for new subroutes.
 
-`.github/workflows` contains our CI/CD config. It deploys the Lambdas on every push to `main`.
+
+
+# Branches and deployment
+- `.github/workflows` contains our CI/CD config
+- `dev` is the default branch (make PRs against `dev`)
+- merges to `dev` trigger deployment to our `GardenApp-dev` and `GardenAuthorizer-dev` lambdas
+- likewise, merges to `prod` deploy `GardenApp-prod` and `GardenAuthorizer-prod` lambdas
+ 
+The `dev` branch is the source of truth for development in this repo. `prod` only exists for deployment purposes. Any changes to `prod` that aren't on `dev` will be lost in time, like tears in rain 🤖🌧️. 


### PR DESCRIPTION
Mini PR to update the readme and GH action now that I've gone ahead and renamed `main` to `prod` on GitHub. Doubles as a sample PR workflow to make sure that branch protection rule(s) aren't too cumbersome 