### PR TITLE
Dump the whole search task response in case of error

### DIFF
--- a/app/search_record.py
+++ b/app/search_record.py
@@ -69,9 +69,5 @@ def publish(event, _context, _kwargs):
     else:
         return {
             "statusCode": 500,
-            "body": json.dumps(
-                {
-                    "message": f"The publication process failed. Globus responded with: {task_result['fatal_error']}"
-                },
-            ),
+            "body": json.dumps(task_result),
         }


### PR DESCRIPTION
I'm getting a KeyError on the backend where we try to extract the error message from the search response in case of failure.

```
[ERROR] KeyError: 'fatal_error'
Traceback (most recent call last):
  File "/var/task/lambda_function.py", line 11, in lambda_handler
    return app.run(event, context)
  File "/var/task/tiny_router.py", line 66, in run
    return path_func(aws_event, aws_context, kwargs)
  File "/var/task/search_record.py", line 74, in publish
    "message": f"The publication process failed. Globus responded with: {task_result['fatal_error']}"
  File "/var/task/globus_sdk/response.py", line 159, in __getitem__
    return data[key]
```

This is an iterative debugging change to get better logs while I figure out the issue.