### PR TITLE
Log raw text response on search failures

### DIFF
--- a/app/search_record.py
+++ b/app/search_record.py
@@ -69,5 +69,5 @@ def publish(event, _context, _kwargs):
     else:
         return {
             "statusCode": 500,
-            "body": json.dumps(task_result),
+            "body": task_result.text,
         }


### PR DESCRIPTION
Follow-up to #41. A GlobusHTTPResponse kind of looks like a string -> string dict but it has some unserializable properties, so you can't just json.dump it. This PR dumps the text to keep debugging
