### PR TITLE
Add new notebook buckets and route that writes to them

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          pip install --upgrade pip
           python -m pip install -r ./app/requirements.txt && python -m pip install -r ./app/test-requirements.txt
 
       - name: Test with pytest

--- a/app/lambda_function.py
+++ b/app/lambda_function.py
@@ -2,6 +2,7 @@ import json
 
 from doi import call_datacite
 from search_record import publish
+from notebooks import upload_notebook
 from tiny_router import TinyLambdaRouter
 
 app = TinyLambdaRouter()
@@ -28,3 +29,4 @@ app.route("/doi", methods=["POST", "PUT"])(
     call_datacite
 )  # equivalent to decorator syntax
 app.route("/garden-search-record", methods=["POST"])(publish)
+app.route("/notebook", methods=["POST"])(upload_notebook)

--- a/app/notebooks.py
+++ b/app/notebooks.py
@@ -1,0 +1,33 @@
+import boto3
+import json
+import hashlib
+from utils import get_environment_from_arn
+
+
+PROD_NOTEBOOK_BUCKET = "pipeline-notebooks-prod"
+DEV_NOTEBOOK_BUCKET = "pipeline-notebooks-dev"
+
+def upload_notebook(event, _context, _kwargs):
+    bucket = PROD_NOTEBOOK_BUCKET if get_environment_from_arn() == "prod" else DEV_NOTEBOOK_BUCKET
+    hash_object = hashlib.sha256(event["body"].encode())
+    hash = hash_object.hexdigest()
+
+    # Get the notebook JSON from the request body
+    body = json.loads(event["body"])
+    notebook_json = body["notebook_json"]
+    notebook_name = body["notebook_name"]
+    folder = body["folder"] or "misc"
+    object_path = f"{folder}/{notebook_name}-{hash}.ipynb"
+
+    # Upload the notebook JSON to S3
+    print(f"Uploading notebook to s3://{bucket}/{object_path}")
+    s3 = boto3.client("s3")
+    s3.put_object(Body=notebook_json, Bucket=bucket, Key=object_path)
+
+    # Generate a public URL for the uploaded notebook
+    s3_url = f"https://{bucket}.s3.amazonaws.com/{object_path}"
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"notebook_url": s3_url}),
+    }

--- a/app/test_app.py
+++ b/app/test_app.py
@@ -57,3 +57,12 @@ def test_garden_search_record(mocker) -> None:
     assert lambda_handler(event, None)["statusCode"] == 500
     mocker.patch("globus_sdk.SearchClient.get_task", return_value={"state": "SUCCESS", "task_id": "uuid-here", "fatal_error": "Globus error"})
     assert lambda_handler(event, None)["statusCode"] == 200
+
+
+simple_notebook = json.dumps({"cells": [], "nbformat": 4, "nbformat_minor": 2})
+def test_notebook(mocker) -> None:
+    mocker.patch("boto3.client")
+    event = {"path": "/notebook", "httpMethod": "POST", "body": json.dumps({"notebook_json": simple_notebook, "notebook_name": "notebook_name", "folder": "folder"})}
+    response = lambda_handler(event, None)
+    assert response["statusCode"] == 200
+    assert "notebook_name" in json.loads(response["body"])["notebook_url"]

--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -49,5 +49,7 @@ module "lambda" {
 
 module "s3" {
   source = "../modules/s3"
+  
+  env    = var.env
 }
 

--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -3,17 +3,26 @@ resource "aws_s3_bucket" "pipeline_notebooks_bucket" {
   tags   = var.tags
 }
 
-resource "aws_s3_bucket_public_access_block" "pipeline_notebooks_access_block" {
+# Allow anyone to read the contents of the bucket
+resource "aws_s3_bucket_policy" "public_read_policy" {
   bucket = aws_s3_bucket.pipeline_notebooks_bucket.id
 
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = true
-  restrict_public_buckets = true
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = "*",
+        Action = "s3:GetObject",
+        Resource = "${aws_s3_bucket.pipeline_notebooks_bucket.arn}/*"
+      }
+    ]
+  })
 }
 
+# But only the backend can write to it
 resource "aws_iam_policy" "s3_full_access" {
-  name        = "s3_full_access"
+  name        = "s3_full_access-${var.env}"
   description = "Full access to notebook bucket"
 
   policy = jsonencode({

--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -1,34 +1,20 @@
-resource "aws_s3_bucket" "prod_models" {
-  bucket = "garden-mlflow-models-prod"
+resource "aws_s3_bucket" "pipeline_notebooks_bucket" {
+  bucket = "pipeline-notebooks-${var.env}"
   tags   = var.tags
 }
 
-resource "aws_s3_bucket" "dev_models" {
-  bucket = "garden-mlflow-models-dev"
-  tags   = var.tags
-}
+resource "aws_s3_bucket_public_access_block" "pipeline_notebooks_access_block" {
+  bucket = aws_s3_bucket.pipeline_notebooks_bucket.id
 
-resource "aws_s3_bucket_public_access_block" "prod" {
-  bucket = aws_s3_bucket.prod_models.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-resource "aws_s3_bucket_public_access_block" "dev" {
-  bucket = aws_s3_bucket.dev_models.id
-
-  block_public_acls       = true
-  block_public_policy     = true
+  block_public_acls       = false
+  block_public_policy     = false
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
 
 resource "aws_iam_policy" "s3_full_access" {
   name        = "s3_full_access"
-  description = "Full access to prod and dev MLFlow model buckets"
+  description = "Full access to notebook bucket"
 
   policy = jsonencode({
     "Version" : "2012-10-17",
@@ -37,10 +23,8 @@ resource "aws_iam_policy" "s3_full_access" {
         "Effect" : "Allow",
         "Action" : "s3:*",
         "Resource" : [
-          "${aws_s3_bucket.prod_models.arn}/*",
-          aws_s3_bucket.prod_models.arn,
-          "${aws_s3_bucket.dev_models.arn}/*",
-          aws_s3_bucket.dev_models.arn
+          "${aws_s3_bucket.pipeline_notebooks_bucket.arn}/*",
+          aws_s3_bucket.pipeline_notebooks_bucket.arn,
         ]
       }
     ]

--- a/infra/modules/s3/variables.tf
+++ b/infra/modules/s3/variables.tf
@@ -2,3 +2,8 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "env" {
+  description = "The environment for the deployment. (dev, prod)"
+  type        = string
+}

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -49,6 +49,8 @@ module "lambda" {
 
 module "s3" {
   source = "../modules/s3"
+
+  env    = var.env
 }
 
 


### PR DESCRIPTION
First part of https://github.com/Garden-AI/garden/issues/345

## Overview

*Infra*
This PR removes the old cruft model buckets and adds new buckets to store .ipynb files.

*Backend app*
This PR also adds a `POST /notebook` route that lets the CLI/SDK upload notebook JSON and get back a public URL where people can GET the notebook JSON later.

## Discussion

*Infra*
I also parameterized the S3 module. There was some weird consequences to two separate terraform states "owning" the same resources.

## Testing

I ran `terraform apply` on both dev and prod. I tested the new route locally and confirmed that it sent me back a valid public URL. I also added a simple unit test for the new route.