### PR TITLE
Dump notebook JSON to string before uploading it to S3

### DIFF
--- a/app/notebooks.py
+++ b/app/notebooks.py
@@ -9,14 +9,16 @@ DEV_NOTEBOOK_BUCKET = "pipeline-notebooks-dev"
 
 def upload_notebook(event, _context, _kwargs):
     bucket = PROD_NOTEBOOK_BUCKET if get_environment_from_arn() == "prod" else DEV_NOTEBOOK_BUCKET
-    hash_object = hashlib.sha256(event["body"].encode())
-    hash = hash_object.hexdigest()
 
-    # Get the notebook JSON from the request body
-    body = json.loads(event["body"])
-    notebook_json = body["notebook_json"]
+    # Get the arguments from the request body
+    body = event["body"]
+    notebook_json = json.dumps(body["notebook_json"])
     notebook_name = body["notebook_name"]
     folder = body["folder"] or "misc"
+
+    # Construct the object path, including a hash of the notebook JSON
+    hash_object = hashlib.sha256(notebook_json.encode())
+    hash = hash_object.hexdigest()
     object_path = f"{folder}/{notebook_name}-{hash}.ipynb"
 
     # Upload the notebook JSON to S3

--- a/app/test_app.py
+++ b/app/test_app.py
@@ -59,7 +59,7 @@ def test_garden_search_record(mocker) -> None:
     assert lambda_handler(event, None)["statusCode"] == 200
 
 
-simple_notebook = json.dumps({"cells": [], "nbformat": 4, "nbformat_minor": 2})
+simple_notebook = {"cells": [], "nbformat": 4, "nbformat_minor": 2}
 def test_notebook(mocker) -> None:
     mocker.patch("boto3.client")
     event = {"path": "/notebook", "httpMethod": "POST", "body": json.dumps({"notebook_json": simple_notebook, "notebook_name": "notebook_name", "folder": "folder"})}


### PR DESCRIPTION
When testing locally I got confused about what the framework does and doesn't serialize/deserialize. That led to a Python dict getting passed to S3 upload instead of a JSON string. This PR fixes that.