### PR TITLE
Open up buckets for requests from browsers

### DIFF
--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -39,3 +39,16 @@ resource "aws_iam_policy" "s3_full_access" {
     ]
   })
 }
+
+# Let browsers access files in the bucket
+resource "aws_s3_bucket_cors_configuration" "pipeline_notebooks_cors" {
+  bucket = aws_s3_bucket.pipeline_notebooks_bucket.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"]
+    expose_headers  = []
+    max_age_seconds = 3000
+  }
+}


### PR DESCRIPTION
A little mop-up from https://github.com/Garden-AI/garden/issues/345

I was getting CORS errors from the UI when requesting the notebook file. This PR opens up the CORS config.
