### PR TITLE
Create public ECR repos for dev and prod

### DIFF
--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -45,6 +45,7 @@ module "lambda" {
   env = var.env
   api_gateway_execution_arn = module.api_gateway.api_execution_arn
   s3_access_policy_arn = module.s3.full_access_arn
+  ecr_access_policy_arn = module.ecr.ecr_backend_write_policy_arn
 }
 
 module "s3" {
@@ -53,3 +54,8 @@ module "s3" {
   env    = var.env
 }
 
+module "ecr" {
+  source = "../modules/ecr"
+
+  env    = var.env
+}

--- a/infra/modules/ecr/main.tf
+++ b/infra/modules/ecr/main.tf
@@ -14,6 +14,7 @@ resource "aws_iam_policy" "ecr_backend_write" {
         Effect    = "Allow",
         Action    = [
           "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
           "ecr:BatchCheckLayerAvailability",
           "ecr:PutImage",
           "ecr:InitiateLayerUpload",

--- a/infra/modules/ecr/main.tf
+++ b/infra/modules/ecr/main.tf
@@ -1,0 +1,27 @@
+
+resource "aws_ecrpublic_repository" "ecr_repo" {
+  repository_name = "garden-containers-${var.env}"
+}
+
+resource "aws_iam_policy" "ecr_backend_write" {
+  name        = "ECRBackendWriteAccess-${var.env}"
+  description = "ECR write access for backend application"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Action    = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload"
+        ],
+        Resource = aws_ecrpublic_repository.ecr_repo.arn,
+      }
+    ]
+  })
+}

--- a/infra/modules/ecr/outputs.tf
+++ b/infra/modules/ecr/outputs.tf
@@ -1,0 +1,3 @@
+output "ecr_backend_write_policy_arn" {
+  value = aws_iam_policy.ecr_backend_write.arn
+}

--- a/infra/modules/ecr/variables.tf
+++ b/infra/modules/ecr/variables.tf
@@ -1,0 +1,4 @@
+variable "env" {
+  description = "The environment for the deployment. (dev, prod)"
+  type        = string
+}

--- a/infra/modules/lambda/main.tf
+++ b/infra/modules/lambda/main.tf
@@ -83,3 +83,8 @@ resource "aws_iam_role_policy_attachment" "s3_access_attach" {
   role       = aws_iam_role.lambda_exec.name
   policy_arn = var.s3_access_policy_arn
 }
+
+resource "aws_iam_role_policy_attachment" "ecr_access_attach" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = var.ecr_access_policy_arn
+}

--- a/infra/modules/lambda/variables.tf
+++ b/infra/modules/lambda/variables.tf
@@ -12,3 +12,8 @@ variable "api_gateway_execution_arn" {
   description = "The execution ARN for the API Gateway."
   type        = string
 }
+
+variable "ecr_access_policy_arn" {
+  description = "The ARN for the ECR access policy to attach to the lambda_exec role."
+  type        = string
+}

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -45,10 +45,17 @@ module "lambda" {
   env = var.env
   api_gateway_execution_arn = module.api_gateway.api_execution_arn
   s3_access_policy_arn = module.s3.full_access_arn
+  ecr_access_policy_arn = module.ecr.ecr_backend_write_policy_arn
 }
 
 module "s3" {
   source = "../modules/s3"
+
+  env    = var.env
+}
+
+module "ecr" {
+  source = "../modules/ecr"
 
   env    = var.env
 }


### PR DESCRIPTION
Closes #48 

## Overview

This PR adds two public ECR repos. One for prod, one for dev. It also attaches a role to the backend lambda app that should give it all the permissions it needs to push images.

## Discussion

I haven't tested this in context of minting STS tokens from the backend. I'm gonna leave that to Max. If there are issues with this config we can revisit it and go from there.

## Testing

Ran terraform apply in dev and prod. Confirmed that the new ECR repos were created.
