### PR TITLE
prod datacite 

### DIFF
--- a/app/doi.py
+++ b/app/doi.py
@@ -13,32 +13,29 @@ def get_datacite_secrets() -> dict[str, str]:
     conf = {}
     if get_environment_from_arn() == "dev":
         conf["REPOSITORY_ID"] = get_secret(
-            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/repo_id-ePlB1w"
+            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/repo_id-dev-r1txQS"
         )
         conf["PASSWORD"] = get_secret(
-            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/password-FFLiwt"
+            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/password-dev-2evQsM"
         )
         conf["ENDPOINT"] = get_secret(
-            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/endpoint-06aepz"
+            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/endpoint-dev-dAYfsL"
         )
         conf["PREFIX"] = get_secret(
-            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/prefix-K6GdzM"
+            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/prefix-dev-FLku4X"
         )
     elif get_environment_from_arn() == "prod":
-        # N.B. these are currently identical b/c we don't want to be using the
-        # real id/password yet, but we can just update this block as soon as
-        # those secrets exist in AWS
         conf["REPOSITORY_ID"] = get_secret(
-            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/repo_id-ePlB1w"
+            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/repo_id-prod-KKaDJ2"
         )
         conf["PASSWORD"] = get_secret(
-            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/password-FFLiwt"
+            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/password-prod-k3VfYZ"
         )
         conf["ENDPOINT"] = get_secret(
-            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/endpoint-06aepz"
+            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/endpoint-prod-81cMhT"
         )
         conf["PREFIX"] = get_secret(
-            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/prefix-K6GdzM"
+            "arn:aws:secretsmanager:us-east-1:557062710055:secret:datacite/prefix-prod-APeKjd"
         )
     return conf
 

--- a/infra/modules/secrets_manager/main.tf
+++ b/infra/modules/secrets_manager/main.tf
@@ -1,26 +1,26 @@
 data "aws_secretsmanager_secret" "datacite_endpoint" {
-  name = "datacite/endpoint"
+  name = "datacite/endpoint-${var.env}"
 }
 data "aws_secretsmanager_secret_version" "datacite_endpoint" {
   secret_id = data.aws_secretsmanager_secret.datacite_endpoint.id
 }
 
 data "aws_secretsmanager_secret" "datacite_password" {
-  name = "datacite/password"
+  name = "datacite/password-${var.env}"
 }
 data "aws_secretsmanager_secret_version" "datacite_password" {
   secret_id = data.aws_secretsmanager_secret.datacite_password.id
 }
 
 data "aws_secretsmanager_secret" "datacite_prefix" {
-  name = "datacite/prefix"
+  name = "datacite/prefix-${var.env}"
 }
 data "aws_secretsmanager_secret_version" "datacite_prefix" {
   secret_id = data.aws_secretsmanager_secret.datacite_prefix.id
 }
 
 data "aws_secretsmanager_secret" "datacite_repo_id" {
-  name = "datacite/repo_id"
+  name = "datacite/repo_id-${var.env}"
 }
 data "aws_secretsmanager_secret_version" "datacite_repo_id" {
   secret_id = data.aws_secretsmanager_secret.datacite_repo_id.id
@@ -40,10 +40,10 @@ resource "aws_iam_policy" "allow_globus_api_key_access_policy" {
           "secretsmanager:GetSecretValue"
         ],
         "Resource" : [
-          "arn:aws:secretsmanager:us-east-1:${var.aws_account_id}:secret:datacite/repo_id-ePlB1w",
-          "arn:aws:secretsmanager:us-east-1:${var.aws_account_id}:secret:datacite/password-FFLiwt",
-          "arn:aws:secretsmanager:us-east-1:${var.aws_account_id}:secret:datacite/endpoint-06aepz",
-          "arn:aws:secretsmanager:us-east-1:${var.aws_account_id}:secret:datacite/prefix-K6GdzM",
+          "arn:aws:secretsmanager:us-east-1:${var.aws_account_id}:secret:datacite/endpoint-${var.env}-*",
+          "arn:aws:secretsmanager:us-east-1:${var.aws_account_id}:secret:datacite/password-${var.env}-*",
+          "arn:aws:secretsmanager:us-east-1:${var.aws_account_id}:secret:datacite/prefix-${var.env}-*",
+          "arn:aws:secretsmanager:us-east-1:${var.aws_account_id}:secret:datacite/repo_id-${var.env}-*",
           "arn:aws:secretsmanager:us-east-1:${var.aws_account_id}:secret:garden/globus_api-2YYuTW"
         ]
       }


### PR DESCRIPTION
fixes #53 

## Discussion

This just updates the secrets_manager terraform module and the datacite creds helper in `doi.py` 

## Testing

Gotta merge to dev in order to test because this changes the secret names for both dev and prod 