### PR TITLE
Delete garden search record

### DIFF
--- a/app/lambda_function.py
+++ b/app/lambda_function.py
@@ -1,7 +1,7 @@
 import json
 
 from doi import call_datacite
-from search_record import publish
+from search_record import publish_search_record, delete_search_record
 from notebooks import upload_notebook
 from tiny_router import TinyLambdaRouter
 from ecr_token import create_ecr_sts_token
@@ -26,9 +26,8 @@ def hello(event, context, kwargs):
     }
 
 
-app.route("/doi", methods=["POST", "PUT"])(
-    call_datacite
-)  # equivalent to decorator syntax
-app.route("/garden-search-record", methods=["POST"])(publish)
+app.route("/doi", methods=["POST", "PUT"])(call_datacite)
+app.route("/garden-search-record", methods=["POST"])(publish_search_record)
+app.route("/garden-search-record", methods=["DELETE"])(delete_search_record)
 app.route("/notebook", methods=["POST"])(upload_notebook)
 app.route("/docker-push-token", methods=["GET"])(create_ecr_sts_token)

--- a/app/search_record.py
+++ b/app/search_record.py
@@ -8,11 +8,7 @@ from utils import get_environment_from_arn, get_secret
 DEV_INDEX = "58e4df29-4492-4e7d-9317-b27eba62a911"
 PROD_INDEX = "813d4556-cbd4-4ba9-97f2-a7155f70682f"
 
-
-def publish(event, _context, _kwargs):
-    GARDEN_INDEX_UUID = (
-        PROD_INDEX if get_environment_from_arn() == "prod" else DEV_INDEX
-    )
+def _get_globus_search_client():
     try:
         globus_secrets = json.loads(
             get_secret(
@@ -33,33 +29,25 @@ def publish(event, _context, _kwargs):
     cc_authorizer = globus_sdk.ClientCredentialsAuthorizer(
         confidential_client, globus_sdk.SearchClient.scopes.all
     )
-    search_client = globus_sdk.SearchClient(authorizer=cc_authorizer)
+    return globus_sdk.SearchClient(authorizer=cc_authorizer)
 
-    garden_meta = json.loads(event["body"])
 
-    gmeta_ingest = {
-        "subject": garden_meta["doi"],
-        "visible_to": ["public"],
-        "content": garden_meta,
-    }
-
-    publish_result = search_client.create_entry(GARDEN_INDEX_UUID, gmeta_ingest)
-
+def _format_response_from_task_result(task_id, search_client):
     max_intervals = 25
-    task_result = search_client.get_task(publish_result["task_id"])
+    task_result = search_client.get_task(task_id)
     while task_result["state"] not in {"FAILED", "SUCCESS"}:
         if not max_intervals:
             return {
                 "statusCode": 408,
                 "body": json.dumps(
                     {
-                        "message": f"Server timed out waiting for publish task to finish, you can manually check its progress with the task id: {task_result['task_id']}"
+                        "message": f"Server timed out waiting for task to finish, you can manually check its progress with the task id: {task_id}"
                     }
                 ),
             }
         sleep(0.2)
         max_intervals -= 1
-        task_result = search_client.get_task(publish_result["task_id"])
+        task_result = search_client.get_task(task_id)
 
     if task_result["state"] == "SUCCESS":
         return {
@@ -71,3 +59,37 @@ def publish(event, _context, _kwargs):
             "statusCode": 500,
             "body": task_result.text,
         }
+
+def publish(event, _context, _kwargs):
+    GARDEN_INDEX_UUID = (
+        PROD_INDEX if get_environment_from_arn() == "prod" else DEV_INDEX
+    )
+    search_client = _get_globus_search_client()
+
+    garden_meta = json.loads(event["body"])
+
+    gmeta_ingest = {
+        "subject": garden_meta["doi"],
+        "visible_to": ["public"],
+        "content": garden_meta,
+    }
+
+    publish_result = search_client.create_entry(GARDEN_INDEX_UUID, gmeta_ingest)
+    response = _format_response_from_task_result(publish_result["task_id"], search_client)
+    return response
+
+
+def delete(event, _context, _kwargs):
+    GARDEN_INDEX_UUID = (
+        PROD_INDEX if get_environment_from_arn() == "prod" else DEV_INDEX
+    )
+    search_client = _get_globus_search_client()
+
+    garden_doi = json.loads(event["body"])["doi"]
+
+    delete_result = search_client.delete_entry(
+        GARDEN_INDEX_UUID, garden_doi
+    )
+
+    response = _format_response_from_task_result(delete_result["task_id"], search_client)
+    return response

--- a/app/search_record.py
+++ b/app/search_record.py
@@ -60,7 +60,7 @@ def _format_response_from_task_result(task_id, search_client):
             "body": task_result.text,
         }
 
-def publish(event, _context, _kwargs):
+def publish_search_record(event, _context, _kwargs):
     GARDEN_INDEX_UUID = (
         PROD_INDEX if get_environment_from_arn() == "prod" else DEV_INDEX
     )
@@ -79,7 +79,7 @@ def publish(event, _context, _kwargs):
     return response
 
 
-def delete(event, _context, _kwargs):
+def delete_search_record(event, _context, _kwargs):
     GARDEN_INDEX_UUID = (
         PROD_INDEX if get_environment_from_arn() == "prod" else DEV_INDEX
     )


### PR DESCRIPTION
Part of #421

## Overview

This PR adds a DELETE variant to /garden-search-record. Specify the DOI of the garden you want removed, and it will do so.

## Discussion

There is deliberately still no access control. Holding off on that until the Real App.

## Testing

I did some manual testing in dev - farewell MaxTestGarden3. Also added a unit test for the new route.