### PR TITLE
Revamp/docker push token

### DIFF
--- a/garden-backend-service/src/api/routes/docker_push_token.py
+++ b/garden-backend-service/src/api/routes/docker_push_token.py
@@ -1,0 +1,70 @@
+import json
+
+import boto3
+from fastapi import APIRouter, Depends, status
+from src.config import Settings, get_settings
+
+from ..dependencies.auth import AuthenticationState, authenticated
+from ..schemas.docker import ECRPushCredentials
+
+router = APIRouter(prefix="/docker-push-token")
+
+
+@router.get("/", status_code=status.HTTP_200_OK)
+async def get_push_session(
+    settings: Settings = Depends(get_settings),
+    _auth: AuthenticationState = Depends(authenticated),
+) -> ECRPushCredentials:
+
+    sts_client = boto3.client("sts")
+    user_policy = _build_user_policy(settings.ECR_REPO_ARN)
+
+    # Assume a role to get temporary credentials
+    assumed_role = sts_client.assume_role(
+        RoleArn=settings.ECR_ROLE_ARN,
+        RoleSessionName="ECR_TOKEN_ROLE",
+        DurationSeconds=settings.STS_TOKEN_TIMEOUT,
+        Policy=user_policy,
+    )
+
+    credentials = assumed_role["Credentials"]
+    return ECRPushCredentials(**credentials)
+
+
+def _build_user_policy(ecr_repo_arn: str) -> str:
+    user_policy = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "ecr-public:GetDownloadUrlForLayer",
+                        "ecr-public:BatchGetImage",
+                        "ecr-public:BatchCheckLayerAvailability",
+                        "ecr-public:PutImage",
+                        "ecr-public:InitiateLayerUpload",
+                        "ecr-public:UploadLayerPart",
+                        "ecr-public:CompleteLayerUpload",
+                    ],
+                    "Resource": ecr_repo_arn,
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "ecr-public:GetAuthorizationToken",  # so user can get auth token for docker login
+                    ],
+                    "Resource": "*",
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "sts:GetServiceBearerToken",  # needed for ecr-public:GetAuthorizationToken
+                        "sts:AssumeRole",
+                    ],
+                    "Resource": "*",
+                },
+            ],
+        }
+    )
+    return user_policy

--- a/garden-backend-service/src/api/routes/docker_push_token.py
+++ b/garden-backend-service/src/api/routes/docker_push_token.py
@@ -4,8 +4,8 @@ import boto3
 from fastapi import APIRouter, Depends, status
 from src.config import Settings, get_settings
 
-from ..dependencies.auth import AuthenticationState, authenticated
-from ..schemas.docker import ECRPushCredentials
+from src.api.dependencies.auth import AuthenticationState, authenticated
+from src.api.schemas.docker import ECRPushCredentials
 
 router = APIRouter(prefix="/docker-push-token")
 
@@ -15,7 +15,6 @@ async def get_push_session(
     settings: Settings = Depends(get_settings),
     _auth: AuthenticationState = Depends(authenticated),
 ) -> ECRPushCredentials:
-
     sts_client = boto3.client("sts")
     user_policy = _build_user_policy(settings.ECR_REPO_ARN)
 
@@ -28,7 +27,7 @@ async def get_push_session(
     )
 
     credentials = assumed_role["Credentials"]
-    return ECRPushCredentials(**credentials)
+    return ECRPushCredentials(**credentials, ECRRepo=settings.ECR_REPO_ARN)
 
 
 def _build_user_policy(ecr_repo_arn: str) -> str:

--- a/garden-backend-service/src/api/schemas/docker.py
+++ b/garden-backend-service/src/api/schemas/docker.py
@@ -1,12 +1,9 @@
 from pydantic import BaseModel
-from src.config import get_settings
-
-settings = get_settings()
 
 
 class ECRPushCredentials(BaseModel):
     AccessKeyId: str
     SecretAccessKey: str
     SessionToken: str
-    ECRRepo: str = settings.ECR_REPO_ARN
+    ECRRepo: str
     RegionName: str = "us-east-1"

--- a/garden-backend-service/src/api/schemas/docker.py
+++ b/garden-backend-service/src/api/schemas/docker.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+from src.config import get_settings
+
+settings = get_settings()
+
+
+class ECRPushCredentials(BaseModel):
+    AccessKeyId: str
+    SecretAccessKey: str
+    SessionToken: str
+    ECRRepo: str = settings.ECR_REPO_ARN
+    RegionName: str = "us-east-1"

--- a/garden-backend-service/src/config.py
+++ b/garden-backend-service/src/config.py
@@ -35,6 +35,10 @@ class Settings(BaseSettings):
     DATACITE_ENDPOINT: str
     DATACITE_PREFIX: str
 
+    ECR_REPO_ARN: str
+    ECR_ROLE_ARN: str
+    STS_TOKEN_TIMEOUT: int = 30 * 60  # 30 min timeout for ecr push
+
     class Config:
         case_sensitive = True
         env_file = _dotenv_path

--- a/garden-backend-service/src/main.py
+++ b/garden-backend-service/src/main.py
@@ -1,10 +1,11 @@
 from fastapi import FastAPI
-from src.api.routes import greet, doi
+from src.api.routes import greet, doi, docker_push_token
 
 app = FastAPI()
 
 app.include_router(greet.router)
 app.include_router(doi.router)
+app.include_router(docker_push_token.router)
 
 
 @app.get("/")

--- a/garden-backend-service/tests/test_routes.py
+++ b/garden-backend-service/tests/test_routes.py
@@ -1,5 +1,6 @@
 import pytest
 import requests
+import json
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock, patch
 
@@ -21,12 +22,21 @@ def mock_auth_state():
 
 @pytest.fixture(autouse=True)
 def mock_boto3_get_secret_value():
+    # dummy values for config read from secrets
+    MOCK_SECRETS_CONFIG_SETTINGS = {
+        "DATACITE_PREFIX": "PREFIX",
+        "DATACITE_ENDPOINT": "ENDPOINT",
+        "DATACITE_REPO_ID": "REPO_ID",
+        "DATACITE_PASSWORD": "PASSWORD",
+        "ECR_REPO_ARN": "ECR_REPO_ARN",
+        "ECR_ROLE_ARN": "ECR_ROLE_ARN",
+    }
     # Typical secret response format
     mock_secret_value_response = {
         "ARN": "arn:aws:secretsmanager:us-east-1:1234567890:secret:test",
         "Name": "test",
         "VersionId": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
-        "SecretString": '{"DATACITE_PREFIX": "PREFIX", "DATACITE_ENDPOINT": "ENDPOINT", "DATACITE_REPO_ID": "REPO_ID", "DATACITE_PASSWORD": "PASSWORD"}',
+        "SecretString": json.dumps(MOCK_SECRETS_CONFIG_SETTINGS),
         "VersionStages": ["AWSCURRENT"],
         "CreatedDate": "2021-01-22T21:46:32.725000+08:00",
     }
@@ -43,7 +53,15 @@ def mock_settings():
     mock_settings.DATACITE_ENDPOINT = "http://localhost:8000"
     mock_settings.DATACITE_REPO_ID = "REPO_ID"
     mock_settings.DATACITE_PASSWORD = "PASSWORD"
+    mock_settings.ECR_REPO_ARN = "ECR_REPO_ARN"
+    mock_settings.ECR_ROLE_ARN = "ECR_ROLE_ARN"
+    mock_settings.STS_TOKEN_TIMEOUT = 0
     return mock_settings
+
+
+@pytest.fixture(autouse=True)
+def mock_get_settings(monkeypatch, mock_settings):
+    monkeypatch.setattr("src.config.get_settings", lambda: mock_settings)
 
 
 @pytest.fixture
@@ -127,3 +145,25 @@ def test_update_datacite(
 
     assert response.status_code == 200
     assert response.json() == mock_request_body
+
+
+def test_get_push_session(
+    override_get_settings_dependency, override_authenticated_dependency
+):
+    mock_assume_role = {
+        "Credentials": {
+            "AccessKeyId": "testAccessKey",
+            "SecretAccessKey": "testSecretKey",
+            "SessionToken": "testSessionToken",
+        }
+    }
+
+    with patch("boto3.client") as mock_client:
+        client_instance = mock_client.return_value
+        client_instance.assume_role.return_value = mock_assume_role
+
+        response = client.get("/docker-push-token/")
+
+    assert response.status_code == 200
+    for key in ["AccessKeyId", "SecretAccessKey", "SessionToken", "ECRRepo"]:
+        assert key in response.json()

--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -62,7 +62,8 @@ module "ecr" {
 }
 
 module "lightsail" {
-  source         = "../modules/lightsail"
-  aws_account_id = var.aws_account_id
-  env            = var.env
+  source                = "../modules/lightsail"
+  aws_account_id        = var.aws_account_id
+  env                   = var.env
+  ecr_access_policy_arn = module.ecr.ecr_backend_write_policy_arn
 }

--- a/infra/modules/lambda/main.tf
+++ b/infra/modules/lambda/main.tf
@@ -99,7 +99,7 @@ resource "aws_iam_role_policy_attachment" "s3_access_attach" {
   policy_arn = var.s3_access_policy_arn
 }
 
-  resource "aws_iam_role_policy_attachment" "ecr_access_attach" {
-    role       = aws_iam_role.assumable_role.name
-    policy_arn = var.ecr_access_policy_arn
-  }
+resource "aws_iam_role_policy_attachment" "ecr_access_attach" {
+  role       = aws_iam_role.assumable_role.name
+  policy_arn = var.ecr_access_policy_arn
+}

--- a/infra/modules/lightsail/main.tf
+++ b/infra/modules/lightsail/main.tf
@@ -38,3 +38,50 @@ resource "aws_iam_user_policy_attachment" "lightsail_user_secrets_policy_attachm
   user       = aws_iam_user.lightsail_user.name
   policy_arn = aws_iam_policy.secrets_policy.arn
 }
+
+# duplicated from lambda module
+# define "ecr-pusher" role for lightsail user to assume
+resource "aws_iam_role" "assumable_role" {
+  name = "ecr-pusher-${var.env}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          AWS = [
+            aws_iam_user.lightsail_user.arn
+          ]
+        },
+      },
+    ],
+  })
+}
+
+# attach ecr backend write policy to assumable role
+resource "aws_iam_role_policy_attachment" "ecr_access_attach" {
+  role       = aws_iam_role.assumable_role.name
+  policy_arn = var.ecr_access_policy_arn
+}
+
+# make and attach policy allowing lightsail IAM user to assume role
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    resources = [aws_iam_role.assumable_role.arn]
+  }
+}
+
+resource "aws_iam_policy" "allow_assume_role_policy" {
+  name = "allow_assume_role_policy_${var.env}"
+  policy = data.aws_iam_policy_document.assume_role_policy.json
+}
+
+resource "aws_iam_user_policy_attachment" "allow_assume_role_attachment" {
+  user = aws_iam_user.lightsail_user.name
+  policy_arn = aws_iam_policy.allow_assume_role_policy.arn
+}
+

--- a/infra/modules/lightsail/variables.tf
+++ b/infra/modules/lightsail/variables.tf
@@ -7,3 +7,8 @@ variable "aws_account_id" {
   description = "The AWS account ID where the resources will be created."
   type        = string
 }
+
+variable "ecr_access_policy_arn" {
+  description = "The ARN for the ECR access policy to attach."
+  type        = string
+}

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -62,9 +62,10 @@ module "ecr" {
 }
 
 module "lightsail" {
-  source         = "../modules/lightsail"
-  aws_account_id = var.aws_account_id
-  env            = var.env
+  source                = "../modules/lightsail"
+  aws_account_id        = var.aws_account_id
+  env                   = var.env
+  ecr_access_policy_arn = module.ecr.ecr_backend_write_policy_arn
 }
 
 /* (prod only) connect api.thegardens.ai to the gateway */


### PR DESCRIPTION
closes #62 
## Overview

This implements the /docker-push-token endpoint for the revamp. the new terraform is almost identical to the analogous terraform in the lambda module. 

I also added a few entries to the `garden-backend-env-vars/dev` and `/prod` secrets for the corresponding ECR repos and IAM roles to assume 

## Testing
Tested against a dev container locally but with the same credentials as the live dev instance to test that it was reading from secretsmanager and assuming the role correctly. I didn't actually try pushing a container or anything, just made sure that the request body coming back looked right with ECR session tokens where the sdk would expect them.

I even tossed in a unit test