### PR TITLE
Revamp/garden search record

### DIFF
--- a/garden-backend-service/src/api/dependencies/auth.py
+++ b/garden-backend-service/src/api/dependencies/auth.py
@@ -5,7 +5,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from src.auth.auth_state import AuthenticationState
 
 
-logger = logging.getLogger("app")
+logger = logging.getLogger()
 
 
 def _get_auth_token(

--- a/garden-backend-service/src/api/dependencies/search.py
+++ b/garden-backend-service/src/api/dependencies/search.py
@@ -1,0 +1,17 @@
+import logging
+
+import globus_sdk
+from fastapi import Depends
+from src.auth.globus_auth import get_auth_client
+
+logger = logging.getLogger()
+
+
+def get_globus_search_client(
+    auth_client: globus_sdk.ConfidentialAppAuthClient = Depends(get_auth_client),
+) -> globus_sdk.SearchClient:
+    cc_authorizer = globus_sdk.ClientCredentialsAuthorizer(
+        auth_client, scopes=globus_sdk.SearchClient.scopes.all
+    )
+    search_client = globus_sdk.SearchClient(authorizer=cc_authorizer)
+    return search_client

--- a/garden-backend-service/src/api/routes/garden_search_record.py
+++ b/garden-backend-service/src/api/routes/garden_search_record.py
@@ -1,0 +1,96 @@
+import asyncio
+
+import requests
+from fastapi import APIRouter, Depends, exceptions, status
+from globus_sdk import SearchClient
+from src.api.dependencies.auth import AuthenticationState, authenticated
+from src.api.dependencies.search import get_globus_search_client
+from src.api.schemas.search import DeleteSearchRecordRequest, PublishSearchRecordRequest
+from src.config import Settings, get_settings
+
+router = APIRouter(prefix="/garden-search-record")
+
+
+@router.post("/", status_code=status.HTTP_200_OK)
+async def publish_search_record(
+    garden_meta: PublishSearchRecordRequest,
+    settings: Settings = Depends(get_settings),
+    search_client: SearchClient = Depends(get_globus_search_client),
+    _auth: AuthenticationState = Depends(authenticated),
+):
+    gmeta_ingest = {
+        "subject": garden_meta.doi,
+        "visible_to": ["public"],
+        "content": garden_meta.dict(),
+    }
+    search_create_result = search_client.create_entry(
+        settings.GLOBUS_SEARCH_INDEX_ID, gmeta_ingest
+    )
+    task_id = search_create_result["task_id"]
+    return await _poll_globus_search_task(task_id, search_client)
+
+
+@router.delete("/", status_code=status.HTTP_200_OK)
+async def delete_search_record(
+    body: DeleteSearchRecordRequest,
+    settings: Settings = Depends(get_settings),
+    search_client: SearchClient = Depends(get_globus_search_client),
+    _auth: AuthenticationState = Depends(authenticated),
+):
+    if is_doi_registered(body.doi):
+        raise exceptions.HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail=f"Error: DOI {body.doi} has been publicly registered and cannot be deleted.",
+        )
+    search_delete_result = search_client.delete_entry(
+        settings.GLOBUS_SEARCH_INDEX_ID, body.doi
+    )
+    task_id = search_delete_result["task_id"]
+    return await _poll_globus_search_task(task_id, search_client)
+
+
+async def _poll_globus_search_task(
+    task_id, search_client: SearchClient, max_intervals=25
+):
+    task_result = search_client.get_task(task_id)
+    while task_result["state"] not in {"FAILED", "SUCCESS"}:
+        if max_intervals == 0:
+            raise exceptions.HTTPException(
+                status.HTTP_408_REQUEST_TIMEOUT,
+                detail=(
+                    "Server timed out waiting for globus search task to finish. "
+                    f"You can manually check its progress with the task id: {task_id}"
+                ),
+            )
+        await asyncio.sleep(0.2)
+        max_intervals -= 1
+        task_result = search_client.get_task(task_id)
+
+    if task_result["state"] == "SUCCESS":
+        return {}
+    else:
+        raise exceptions.HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, detail=task_result.text
+        )
+
+
+def is_doi_registered(doi):
+    """
+    Check if a DOI is registered by querying the DOI.org resolver.
+
+    Parameters:
+    doi (str): The DOI to check.
+
+    Returns:
+    bool: True if the DOI resolves successfully, False otherwise.
+    """
+    url = f"https://doi.org/{doi}"
+
+    headers = {"Accept": "application/vnd.citationstyles.csl+json"}
+    response = requests.get(url, headers=headers, allow_redirects=False)
+
+    # Check if the response status code is a redirect (300-399), indicating the DOI is registered
+    if 300 <= response.status_code < 400:
+        return True
+    else:
+        return False

--- a/garden-backend-service/src/api/schemas/datacite/__init__.py
+++ b/garden-backend-service/src/api/schemas/datacite/__init__.py
@@ -8,7 +8,7 @@ https://github.com/datacite/lupo/blob/master/openapi.yaml using the
 In some cases, the actual behavior of the datacite API might not correspond to
 the auto-generated schema. It's fine to tweak the auto-generated models in those cases,
 otherwise if we want to change the behavior of some sub-field prefer inheriting with our own
-pydantic class (like below) .
+pydantic class (like below).
 """
 from ._full_schema import Doi as _Doi
 from ._full_schema import Data3, DoiAttributes

--- a/garden-backend-service/src/api/schemas/search/__init__.py
+++ b/garden-backend-service/src/api/schemas/search/__init__.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from ._garden_sdk_schema import _PublishedGarden
+
+
+class PublishSearchRecordRequest(_PublishedGarden):
+    pass
+
+
+class DeleteSearchRecordRequest(BaseModel):
+    doi: str
+
+
+__all__ = ["PublishSearchRecordRequest", "DeleteSearchRecordRequest"]

--- a/garden-backend-service/src/api/schemas/search/__init__.py
+++ b/garden-backend-service/src/api/schemas/search/__init__.py
@@ -1,9 +1,5 @@
 from pydantic import BaseModel
-from ._garden_sdk_schema import _PublishedGarden
-
-
-class PublishSearchRecordRequest(_PublishedGarden):
-    pass
+from ._garden_sdk_schema import _PublishedGarden as PublishSearchRecordRequest
 
 
 class DeleteSearchRecordRequest(BaseModel):

--- a/garden-backend-service/src/api/schemas/search/_garden_sdk_schema.py
+++ b/garden-backend-service/src/api/schemas/search/_garden_sdk_schema.py
@@ -1,0 +1,86 @@
+"""Pydantic schemas equivalent to their counterparts in the garden-ai sdk, as of v1.0.10"""
+from pydantic import BaseModel, Field
+from typing import List, Dict, Optional
+from uuid import UUID
+import datetime
+
+
+class _Repository(BaseModel):
+    repo_name: str = Field(...)
+    url: str = Field(...)
+    contributors: List[str] = Field(default_factory=list)
+
+
+class _Paper(BaseModel):
+    title: str = Field(...)
+    authors: List[str] = Field(default_factory=list)
+    doi: Optional[str] = Field(None)
+    citation: Optional[str] = Field(None)
+
+
+class _Step(BaseModel):
+    function_name: str = Field(...)
+    function_text: str = Field(...)
+    description: Optional[str] = Field(None)
+
+
+class _DatasetConnection(BaseModel):
+    title: str = Field(...)
+    doi: Optional[str] = Field(None)
+    url: str = Field(...)
+    data_type: Optional[str] = Field(None)
+    repository: str = Field(...)
+
+
+class _ModelMetadata(BaseModel):
+    model_identifier: str = Field(...)
+    model_repository: str = Field(...)
+    model_version: Optional[str] = Field(None)
+    datasets: List[_DatasetConnection] = Field(default_factory=list)
+
+
+class _EntrypointMetadata(BaseModel):
+    doi: Optional[str] = Field(None)
+    title: str = Field(...)
+    authors: List[str] = Field(...)
+    short_name: Optional[str] = Field(None)
+    description: Optional[str] = Field(None)
+    year: str = Field(default_factory=lambda: str(datetime.now().year))
+    tags: List[str] = Field(default_factory=list, unique_items=True)
+    models: List[_ModelMetadata] = Field(default_factory=list)
+    repositories: List[_Repository] = Field(default_factory=list)
+    papers: List[_Paper] = Field(default_factory=list)
+    datasets: List[_DatasetConnection] = Field(default_factory=list)
+    # The PrivateAttrs below are used internally for publishing.
+    # _test_functions: List[str] = PrivateAttr(default_factory=list)
+    # _target_garden_doi: Optional[str] = PrivateAttr(None)
+    # _as_step: Optional[_Step] = PrivateAttr(None)
+
+
+class _RegisteredEntrypoint(_EntrypointMetadata):
+    doi: str = Field(
+        ...
+    )  # Repeating this field from base class because DOI is mandatory for RegisteredEntrypoint
+    doi_is_draft: bool = Field(True)
+    func_uuid: UUID = Field(...)
+    container_uuid: UUID = Field(...)
+    base_image_uri: Optional[str] = Field(None)
+    full_image_uri: Optional[str] = Field(None)
+    notebook_url: Optional[str] = Field(None)
+    steps: List[_Step] = Field(default_factory=list)
+    test_functions: List[str] = Field(default_factory=list)
+
+
+class _PublishedGarden(BaseModel):
+    title: str = Field(...)
+    authors: List[str] = Field(...)
+    contributors: List[str] = Field(default_factory=list, unique_items=True)
+    doi: str = Field(...)
+    description: Optional[str] = Field(None)
+    publisher: str = "Garden-AI"
+    year: str = Field(default_factory=lambda: str(datetime.now().year))
+    language: str = "en"
+    tags: List[str] = Field(default_factory=list, unique_items=True)
+    version: str = "0.0.1"
+    entrypoints: List[_RegisteredEntrypoint] = Field(...)
+    entrypoint_aliases: Dict[str, str] = Field(default_factory=dict)

--- a/garden-backend-service/src/auth/auth_state.py
+++ b/garden-backend-service/src/auth/auth_state.py
@@ -66,7 +66,7 @@ class AuthenticationState:
 
     def assert_has_scope(self, scope: str) -> None:
         if scope not in self.scopes:
-            raise HTTPException(status_code=403, detail="Missing Scopes")
+            raise HTTPException(status_code=403, detail=f"Missing Scope: {scope}")
 
     def assert_has_default_scope(self) -> None:
         self.assert_has_scope(self.garden_default_scope)

--- a/garden-backend-service/src/config.py
+++ b/garden-backend-service/src/config.py
@@ -41,6 +41,8 @@ class Settings(BaseSettings):
 
     NOTEBOOKS_S3_BUCKET: str
 
+    GLOBUS_SEARCH_INDEX_ID: str
+
     class Config:
         case_sensitive = True
         env_file = _dotenv_path

--- a/garden-backend-service/src/main.py
+++ b/garden-backend-service/src/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
-from src.api.routes import greet, doi, docker_push_token, notebook
+
+from src.api.routes import docker_push_token, doi, garden_search_record, greet, notebook
 
 app = FastAPI()
 
@@ -7,6 +8,7 @@ app.include_router(greet.router)
 app.include_router(doi.router)
 app.include_router(docker_push_token.router)
 app.include_router(notebook.router)
+app.include_router(garden_search_record.router)
 
 
 @app.get("/")

--- a/garden-backend-service/tests/test_routes.py
+++ b/garden-backend-service/tests/test_routes.py
@@ -185,4 +185,4 @@ def test_upload_notebook(
             Key=f"{request_obj.folder}/{request_obj.notebook_name}-{test_hash}.ipynb",
         )
 
-    pass
+    return


### PR DESCRIPTION
closes #60 

## Overview
This PR implements the `/garden-search-record/` routes to publish garden metadata to (and delete from) the appropriate globus search index. This means the revamped backend can officially do everything the old one can (🎉🥳🍾)

## Discussion
The only change in behavior vs. the old backend is that we now do the `is_doi_registered` check before actually deleting. 

This PR is the first place I've introduced the actual concept of a `Garden` or `Entrypoint` to a schema - specifically, I copied over any pydantic models we might need to validate a `PublishedGarden.json()` request body. 

I made an organizational judgement call to keep those buried as part of a `schemas.search` submodule (rather than enshrining them in something like `schemas.garden_ai`) since this is just the schema that the search index is going to use as long as it stays around. I.e. these are the schemas specifically for a "garden search record", not any garden in general. 

## Testing

manually with the CLI and local test instance of the app. skipped the unit test for this one since I don't think the `/garden-search-record/` routes will have a long enough shelf life to really justify it 