### PR TITLE
Revamp/api subdomains

### DIFF
--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -62,9 +62,33 @@ module "ecr" {
 }
 
 module "lightsail" {
-  source                = "../modules/lightsail"
-  aws_account_id        = var.aws_account_id
-  env                   = var.env
-  ecr_access_policy_arn = module.ecr.ecr_backend_write_policy_arn
-  s3_access_policy_arn  = module.s3.full_access_arn
+  source                            = "../modules/lightsail"
+  aws_account_id                    = var.aws_account_id
+  env                               = var.env
+  ecr_access_policy_arn             = module.ecr.ecr_backend_write_policy_arn
+  s3_access_policy_arn              = module.s3.full_access_arn
+  lightsail_certificate_name        = "api-dev-certificate"
+  lightsail_certificate_domain_name = data.aws_acm_certificate.api_cert.domain
+}
+
+/* point api-dev.thegardens.ai to the lightsail deployment */
+
+data "aws_route53_zone" "hosted_zone" {
+  name = "thegardens.ai"
+}
+
+data "aws_acm_certificate" "api_cert" {
+  domain = "api-dev.thegardens.ai"
+}
+
+resource "aws_route53_record" "api_record" {
+  name    = data.aws_acm_certificate.api_cert.domain
+  type    = "A"
+  zone_id = data.aws_route53_zone.hosted_zone.id
+
+  alias {
+    evaluate_target_health = true
+    name                   = module.lightsail.container_service_domain
+    zone_id                = module.lightsail.lightsail_container_service_hosted_zone_id
+  }
 }

--- a/infra/modules/lightsail/outputs.tf
+++ b/infra/modules/lightsail/outputs.tf
@@ -13,6 +13,17 @@ output "container_service_url" {
   value       = aws_lightsail_container_service.garden_service.url
 }
 
+output "container_service_domain" {
+  description = "The domain name of the container service deployment"
+  value       = trimsuffix(replace(aws_lightsail_container_service.garden_service.url, "https://", ""), "/")
+}
+
+output "lightsail_container_service_hosted_zone_id" {
+  description = "The (fixed) hosted zone ID for lightsail container services in us-east-1"
+  value       = "Z06246771KYU0IRHI74W4"
+  # see: https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-route-53-alias-record-for-container-service.html#route-53-container-service-hosted-zone-ids
+}
+
 output "lightsail_iam_user_name" {
   value = aws_iam_user.lightsail_user.name
 }

--- a/infra/modules/lightsail/variables.tf
+++ b/infra/modules/lightsail/variables.tf
@@ -17,3 +17,14 @@ variable "s3_access_policy_arn" {
   description = "The ARN for the S3 access policy to attach."
   type        = string
 }
+
+variable "lightsail_certificate_name" {
+  description = "The name of the lightsail certificate for the custom domain, e.g. 'api-dev-certificate'."
+  type = string
+}
+
+variable "lightsail_certificate_domain_name" {
+  # note: may need to manually add record in route53 if corresponding lightsail cert doesn't already exist
+  description = "The custom domain name for the deployment, e.g. 'api-dev.thegardens.ai'"
+  type = string
+}

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -62,14 +62,16 @@ module "ecr" {
 }
 
 module "lightsail" {
-  source                = "../modules/lightsail"
-  aws_account_id        = var.aws_account_id
-  env                   = var.env
-  ecr_access_policy_arn = module.ecr.ecr_backend_write_policy_arn
-  s3_access_policy_arn  = module.s3.full_access_arn
+  source                            = "../modules/lightsail"
+  aws_account_id                    = var.aws_account_id
+  env                               = var.env
+  ecr_access_policy_arn             = module.ecr.ecr_backend_write_policy_arn
+  s3_access_policy_arn              = module.s3.full_access_arn
+  lightsail_certificate_name        = "api-certificate"
+  lightsail_certificate_domain_name = data.aws_acm_certificate.api_cert.domain
 }
 
-/* (prod only) connect api.thegardens.ai to the gateway */
+/* point api.thegardens.ai to the lightsail deployment */
 
 data "aws_route53_zone" "hosted_zone" {
   name = "thegardens.ai"
@@ -79,20 +81,14 @@ data "aws_acm_certificate" "api_cert" {
   domain = "api.thegardens.ai"
 }
 
-resource "aws_api_gateway_domain_name" "api_domain_name" {
-  certificate_arn = data.aws_acm_certificate.api_cert.arn
-  domain_name     = data.aws_acm_certificate.api_cert.domain
-}
-
-
 resource "aws_route53_record" "api_record" {
-  name    = aws_api_gateway_domain_name.api_domain_name.domain_name
+  name    = data.aws_acm_certificate.api_cert.domain
   type    = "A"
   zone_id = data.aws_route53_zone.hosted_zone.id
 
   alias {
     evaluate_target_health = true
-    name                   = aws_api_gateway_domain_name.api_domain_name.cloudfront_domain_name
-    zone_id                = aws_api_gateway_domain_name.api_domain_name.cloudfront_zone_id
+    name                   = module.lightsail.container_service_domain
+    zone_id                = module.lightsail.lightsail_container_service_hosted_zone_id
   }
 }


### PR DESCRIPTION
completes #77 

## Overview
this PR includes the terraform to point the `api-dev` and `api` subdomains for `thegardens.ai` at their respective lightsail deployments.  

Even though the certificate/dns record stuff was entirely manual (for api-dev, anyways) the `terraform apply` for dev was a no-op, which was a pleasant and encouraging surprise.

## Discussion
Unlike api-dev, the applying changes to prod here would officially switch  `api.thegardens.ai` over from the api gateway backend to the lightsail revamp.
 
Even though we don't actually ever hit api.thegardens.ai from the CLI (does the frontend?), here's the `terraform plan -var-file="prod.tfvars"` output as a sanity check:
```

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
  - destroy

Terraform will perform the following actions:

  # aws_api_gateway_domain_name.api_domain_name will be destroyed
  # (because aws_api_gateway_domain_name.api_domain_name is not in configuration)
  - resource "aws_api_gateway_domain_name" "api_domain_name" {
      - arn                     = "arn:aws:apigateway:us-east-1::/domainnames/api.thegardens.ai" -> null
      - certificate_arn         = "arn:aws:acm:us-east-1:557062710055:certificate/0d01db60-1629-429a-ae73-7734c3124774" -> null
      - certificate_upload_date = "2023-02-16T16:34:22Z" -> null
      - cloudfront_domain_name  = "d2b5gsjkal3ctw.cloudfront.net" -> null
      - cloudfront_zone_id      = "Z2FDTNDATAQYW2" -> null
      - domain_name             = "api.thegardens.ai" -> null
      - id                      = "api.thegardens.ai" -> null
      - security_policy         = "TLS_1_2" -> null
      - tags                    = {} -> null
      - tags_all                = {} -> null

      - endpoint_configuration {
          - types = [
              - "EDGE",
            ] -> null
        }
    }

  # aws_route53_record.api_record will be updated in-place
  ~ resource "aws_route53_record" "api_record" {
        id                               = "Z0503336NYDRDH8NL73K_api.thegardens.ai_A"
        name                             = "api.thegardens.ai"
        # (6 unchanged attributes hidden)

      ~ alias {
          ~ name                   = "d2b5gsjkal3ctw.cloudfront.net" -> "garden-service-prod.0dh7fu9qsbhfi.us-east-1.cs.amazonlightsail.com"
          ~ zone_id                = "Z2FDTNDATAQYW2" -> "Z06246771KYU0IRHI74W4"
            # (1 unchanged attribute hidden)
        }
    }

  # module.lightsail.aws_lightsail_certificate.api_cert will be created
  + resource "aws_lightsail_certificate" "api_cert" {
      + arn                       = (known after apply)
      + created_at                = (known after apply)
      + domain_name               = "api.thegardens.ai"
      + domain_validation_options = (known after apply)
      + id                        = (known after apply)
      + name                      = "api-certificate"
      + subject_alternative_names = [
          + "api.thegardens.ai",
        ]
      + tags_all                  = (known after apply)
    }

  # module.lightsail.aws_lightsail_container_service.garden_service will be updated in-place
  ~ resource "aws_lightsail_container_service" "garden_service" {
        id                  = "garden-service-prod"
        name                = "garden-service-prod"
        tags                = {
            "Component"   = "Lightsail Container Service"
            "Environment" = "prod"
            "Project"     = "Garden"
        }
        # (13 unchanged attributes hidden)

      + public_domain_names {
          + certificate {
              + certificate_name = "api-certificate"
              + domain_names     = [
                  + "api.thegardens.ai",
                ]
            }
        }

        # (1 unchanged block hidden)
    }

Plan: 1 to add, 2 to change, 1 to destroy.

```


## Testing

browse on over to [api-dev.thegardens.ai](https://api-dev.thegardens.ai/) for a worldly (and secure) greeting
