### PR TITLE
Add ability for backend service to automatically add new users to Garden Users Globus group

### DIFF
--- a/garden-backend-service/src/api/dependencies/auth.py
+++ b/garden-backend-service/src/api/dependencies/auth.py
@@ -54,6 +54,6 @@ async def authed_user(
 
     # Add the user to Garden Users Globus group if they are new
     if created:
-        await add_user_to_group(auth, settings)
+        add_user_to_group(auth, settings)
 
     return user

--- a/garden-backend-service/src/api/dependencies/auth.py
+++ b/garden-backend-service/src/api/dependencies/auth.py
@@ -50,7 +50,7 @@ async def authed_user(
         db,
         username=auth.username,
         identity_id=auth.identity_id,
-        defaults={"group_added": false}
+        defaults={"group_added": False}
     )
 
     if created or not user.group_added:

--- a/garden-backend-service/src/api/dependencies/auth.py
+++ b/garden-backend-service/src/api/dependencies/auth.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.dependencies.database import get_db_session
 from src.auth.auth_state import AuthenticationState
-from src.auth.globus_groups import in_garden_group, add_user_to_garden_group
+from src.auth.globus_groups import add_user_to_group
 from src.config import Settings, get_settings
 from src.models.user import User
 
@@ -50,14 +50,10 @@ async def authed_user(
         db,
         username=auth.username,
         identity_id=auth.identity_id,
-        defaults={"group_added": False}
     )
 
-    if created or not user.group_added:
-        if not in_garden_group(auth, settings):
-            await add_user_to_garden_group(auth, settings)
-
-        user.group_added = True
-        await db.commit()
+    # Add the user to Garden Users Globus group if they are new
+    if created:
+        await add_user_to_group(auth, settings)
 
     return user

--- a/garden-backend-service/src/auth/globus_groups.py
+++ b/garden-backend-service/src/auth/globus_groups.py
@@ -104,13 +104,3 @@ def _create_groups_client_with_token(token: str) -> glb.GroupsClient:
     """
     authorizer = glb.AccessTokenAuthorizer(token)
     return glb.GroupsClient(authorizer=authorizer)
-
-
-#TODO DELETE ME BEFORE MAKING A PR!
-def request_to_join():
-    """One time function to have the backend service request to join the Garden Users group"""
-    c = get_auth_client()
-    settings = get_settings()
-    gc = _fetch_user_groups_client()
-    gm = globus_sdk.GroupsManager(client=gc)
-    gm.request_join(settings.GARDEN_USERS_GROUP_ID, settings.API_CLIENT_ID)

--- a/garden-backend-service/src/auth/globus_groups.py
+++ b/garden-backend-service/src/auth/globus_groups.py
@@ -1,0 +1,66 @@
+import globus_sdk as glb
+
+from src.models import User
+from src.config import Settings
+
+from .auth_state import AuthenticationState
+from .globus_auth import get_auth_client
+
+def add_user_to_garden_group(
+    authed_user: AuthenticationState,
+    settings: Settings,
+) -> None:
+    """Add authed_user as a member of Garden Users Globus group specified in the settings.
+
+    If the user is already in the group this function does nothing.
+    """
+    if not in_garden_group(authed_user):
+        gm = _get_service_groups_manager()
+        gm.add_member(settings.GARDEN_USERS_GROUP_ID, authed_user.identity_id)
+
+
+def in_garden_group(
+    authed_user: AuthenticationState,
+    settings: Settings,
+) -> bool:
+    """Return true if authed_user is a member of the Garden Users Globus group specified in the settings."""
+    gc = _get_groups_client_for_token(authed_user.token)
+    groups = _get_groups(gc)
+    return any(group.get("id") == settings.GARDEN_USERS_GROUP_ID for group in groups)
+
+
+def _get_groups(client: glb.GroupsClient) -> list[dict]:
+    """Return a list of group data objects for the given client."""
+    return [group for group in client.get_my_groups()]
+
+
+def _get_service_groups_client() -> glb.GroupsClient:
+    """Return a globus_sdk GroupsClient acting as the backend service."""
+    gc = get_auth_client()
+    tokens = gc.oauth2_client_credentials_tokens(
+        requested_scopes="urn:globus:auth:scope:groups.api.globus.org:all",
+    )
+    auth_data = tokens.by_resource_server.get("groups.api.globus.org")
+    token = auth_data.get("access_token")
+    return _get_groups_client_for_token(token)
+
+
+def _get_service_groups_manager() -> glb.GroupsManager:
+    """Return a globus_sdk GroupsManager acting as the backend service."""
+    gc = _get_servoce_groups_client()
+    return glb.GroupsManager(client=gc)
+
+def _get_groups_client_for_token(token: str) -> glb.GroupsClient:
+    """Return a globus_sdk GroupsClient acting as the user that provides the token."""
+    authorizer = glb.AccessTokenAuthorizer(token)
+    return glb.GroupsClient(authorizer=authorizer)
+
+
+#TODO DELETE ME BEFORE MAKING A PR!
+# def request_to_join():
+#     """One time function to have the backend service request to join the Garden Users group"""
+#     c = get_auth_client()
+#     settings = get_settings()
+#     gc = _get_groups_client()
+#     gm = globus_sdk.GroupsManager(client=gc)
+#     gm.request_join(settings.GARDEN_USERS_GROUP_ID, settings.API_CLIENT_ID)

--- a/garden-backend-service/src/auth/globus_groups.py
+++ b/garden-backend-service/src/auth/globus_groups.py
@@ -11,68 +11,106 @@ from .globus_auth import get_auth_client
 logger = logging.getLogger(__name__)
 
 
-def add_user_to_garden_group(
+def add_user_to_group(
     authed_user: AuthenticationState,
     settings: Settings,
 ) -> None:
     """Add authed_user as a member of Garden Users Globus group specified in the settings.
 
     If the user is already in the group this function does nothing.
+
+    Args:
+        authed_user (AuthenticationState): The authenticated user.
+        settings (Settings): Application settings.
+
+    Raises:
+        globus_sdk.GlobusAPIError: when there is an issue communicating with Globus services
     """
     try:
-        if not in_garden_group(authed_user):
-            gm = _get_service_groups_manager()
-            gm.add_member(settings.GARDEN_USERS_GROUP_ID, authed_user.identity_id)
+        if not is_user_in_group(authed_user, settings):
+            groups_manager = _create_service_groups_manager()
+            groups_manager.add_member(settings.GARDEN_USERS_GROUP_ID, authed_user.identity_id)
     except glb.GlobusAPIError as e:
         logger.error(f"Error adding user to Garden Users Group: {e}")
         raise e
 
-def in_garden_group(
+
+def is_user_in_group(
     authed_user: AuthenticationState,
     settings: Settings,
 ) -> bool:
-    """Return true if authed_user is a member of the Garden Users Globus group specified in the settings."""
+    """Return true if authed_user is a member of the Garden Users Globus group specified in the settings.
+
+    Args:
+        authed_user (AuthenticationState): The authenticated user
+        settings (Settings): Application Settings
+
+    Raises:
+        globus_sdk.GlobusAPIError: When there is an issue communicating with Globus services
+    """
     try:
-        gc = _get_groups_client_for_token(authed_user.token)
-        groups = _get_groups(gc)
+        gc = _create_groups_client_with_token(authed_user.token)
+        groups = _fetch_user_groups(gc)
         return any(group.get("id") == settings.GARDEN_USERS_GROUP_ID for group in groups)
     except glb.GlobusAPIError as e:
         logger.error(f"Error getting user Globus groups: {e}")
         raise e
 
 
-def _get_groups(client: glb.GroupsClient) -> list[dict]:
-    """Return a list of group data objects for the given client."""
+def _fetch_user_groups(client: glb.GroupsClient) -> list[dict]:
+    """Return a list of group data objects for the given client.
+
+    Args:
+        client (globus_sdk.GroupsClient): A groups client.
+
+
+    Returns:
+        list[dict]: List of group data objects.
+            See https://globus-sdk-python.readthedocs.io/en/stable/services/groups.html#globus_sdk.GroupsClient.get_my_groups
+    """
     return [group for group in client.get_my_groups()]
 
 
-def _get_service_groups_client() -> glb.GroupsClient:
-    """Return a globus_sdk GroupsClient acting as the backend service."""
+def _create_service_groups_client() -> glb.GroupsClient:
+    """Return a globus_sdk GroupsClient acting as the backend service.
+
+    Returns:
+        globus_sdk.GroupsClient: Groups client acting as the backend service.
+    """
     gc = get_auth_client()
     tokens = gc.oauth2_client_credentials_tokens(
         requested_scopes="urn:globus:auth:scope:groups.api.globus.org:all",
     )
     auth_data = tokens.by_resource_server.get("groups.api.globus.org")
     token = auth_data.get("access_token")
-    return _get_groups_client_for_token(token)
+    return _create_groups_client_with_token(token)
 
 
-def _get_service_groups_manager() -> glb.GroupsManager:
-    """Return a globus_sdk GroupsManager acting as the backend service."""
-    gc = _get_servoce_groups_client()
+def _create_service_groups_manager() -> glb.GroupsManager:
+    """Return a globus_sdk GroupsManager acting as the backend service.
+
+    Returns:
+        globus_sdk.GroupsManager: Groups manager acting as the backend service.
+    """
+    gc = _create_service_groups_client()
     return glb.GroupsManager(client=gc)
 
-def _get_groups_client_for_token(token: str) -> glb.GroupsClient:
-    """Return a globus_sdk GroupsClient acting as the user that provides the token."""
+
+def _create_groups_client_with_token(token: str) -> glb.GroupsClient:
+    """Return a globus_sdk GroupsClient acting as the user that provides the token.
+
+    Returns:
+       globus_sdk.GroupsClient: Groups client using the provided token.
+    """
     authorizer = glb.AccessTokenAuthorizer(token)
     return glb.GroupsClient(authorizer=authorizer)
 
 
-# #TODO DELETE ME BEFORE MAKING A PR!
-# def request_to_join():
-#     """One time function to have the backend service request to join the Garden Users group"""
-#     c = get_auth_client()
-#     settings = get_settings()
-#     gc = _get_groups_client()
-#     gm = globus_sdk.GroupsManager(client=gc)
-#     gm.request_join(settings.GARDEN_USERS_GROUP_ID, settings.API_CLIENT_ID)
+#TODO DELETE ME BEFORE MAKING A PR!
+def request_to_join():
+    """One time function to have the backend service request to join the Garden Users group"""
+    c = get_auth_client()
+    settings = get_settings()
+    gc = _fetch_user_groups_client()
+    gm = globus_sdk.GroupsManager(client=gc)
+    gm.request_join(settings.GARDEN_USERS_GROUP_ID, settings.API_CLIENT_ID)

--- a/garden-backend-service/src/config.py
+++ b/garden-backend-service/src/config.py
@@ -36,6 +36,8 @@ class Settings(BaseSettings):
         "https://auth.globus.org/scopes/0948a6b0-a622-4078-b0a4-bfd6d77d65cf/action_all"
     )
 
+    GARDEN_USERS_GROUP_ID: str
+
     DATACITE_REPO_ID: str
     DATACITE_PASSWORD: str
     DATACITE_ENDPOINT: str

--- a/garden-backend-service/src/models/base.py
+++ b/garden-backend-service/src/models/base.py
@@ -23,13 +23,15 @@ class Base(AsyncAttrs, DeclarativeBase):
     @classmethod
     async def get_or_create(cls: Type[T], db: AsyncSession, **kwargs: Any) -> T:
         obj = await cls.get(db, **kwargs)
+        created = False
 
         if not obj:
             obj = cls(**kwargs)
             await obj._asave(db)
             await db.refresh(obj)
+            created = True
 
-        return obj
+        return obj, created
 
     async def _asave(self, db: AsyncSession) -> None:
         db.add(self)

--- a/garden-backend-service/src/models/base.py
+++ b/garden-backend-service/src/models/base.py
@@ -21,7 +21,7 @@ class Base(AsyncAttrs, DeclarativeBase):
         return (await db.execute(q)).scalar_one_or_none()
 
     @classmethod
-    async def get_or_create(cls: Type[T], db: AsyncSession, **kwargs: Any) -> T:
+    async def get_or_create(cls: Type[T], db: AsyncSession, **kwargs: Any) -> tuple[T, bool]:
         obj = await cls.get(db, **kwargs)
         created = False
 

--- a/garden-backend-service/src/models/user.py
+++ b/garden-backend-service/src/models/user.py
@@ -10,4 +10,3 @@ class User(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     username: Mapped[str]
     identity_id: Mapped[UUID] = mapped_column(unique=True)
-    group_added: Mapped[bool]

--- a/garden-backend-service/src/models/user.py
+++ b/garden-backend-service/src/models/user.py
@@ -10,3 +10,4 @@ class User(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     username: Mapped[str]
     identity_id: Mapped[UUID] = mapped_column(unique=True)
+    group_added: Mapped[bool]

--- a/garden-backend-service/tests/test_routes.py
+++ b/garden-backend-service/tests/test_routes.py
@@ -12,7 +12,6 @@ from fastapi import HTTPException, Depends
 from fastapi.security import HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-from testcontainers.postgres import PostgresContainer
 
 from src.api.dependencies.auth import (
     AuthenticationState,


### PR DESCRIPTION
Resolves: #91 

## Overview

This PR adds the ability for the backend service to automatically add authed users to the Garden Users Globus group. When a user accesses authenticated endpoints for the first time they are added to the group via the Globus Groups API.

## Changes
 - Added a field to the `Settings` object in `config.py` called `GARDEN_USER_GROUP_ID` which needs to be set in the environment to the UUID of the Garden Users group.

- Added a new module `src/auth/globus_groups.py` where the primary function `add_user_to_group` and its helpers are defined.

## Discussion

To enabe this functionality the backend service was made an administrator of the Garden Users group. This was accomplished by:
- Having the backend service authenticate with Globus, then request to join the group as a regular user
- Give the backend sercvice an administrator role in the group.

## Testing

Added new unit tests that:
- Verify a user is added to the group on their first authenticated request
- Ensure we only add the user to the group once -- this may be unnecessary if the Globus Groups API is idempotent
- Mock the necessary dependencies to isolate the functionality