### PR TITLE
Add EC2 instance to connect pgadmin with RDS instances

### DIFF
--- a/garden-backend-service/README.md
+++ b/garden-backend-service/README.md
@@ -117,43 +117,48 @@ On a push to `dev` or `prod` branches, we run a GitHub action to build and push 
 
 ## Connect pgadmin to RDS instances
 
-Note: You will need to follow this process for each instance. You can
+**Note:** You will need to follow this process for each instance (dev and prod). You can
 use the same key pair for both instances.
 
-1. Create ssh key pair
+### **Create ssh key pair**
+   
 Either through the AWS console or on the command line create an RSA
 keypair.
 
-- Option 1 AWS Console
+- **Option 1 AWS Console**
+  
   Login to AWS and navigate to the EC2 Console. On the left nav panel
-  under network and security select 'Key Pairs'.
+  under network and security select *Key Pairs*.
 
-  Click 'Create key pair'.
+  Click *Create key pair*.
 
-  Select "RSA" for the key pair type and select '.pem' for the format.
+  Select "RSA" for the key pair type and select ".pem" for the format.
 
-  Create the key pair by clicking 'Create key pair' at the bottom of
+  Create the key pair by clicking *Create key pair* at the bottom of
   the page. Make sure to download the generated key pair as this is
   the only opportunity you have to save it. If you lose it you will
   need to create a new one.
 
-- Option 2 local command line
+- **Option 2 local command line**
+  
   Use `ssh-keygen` to generate a key pair locally:
+  
   ```sh
   ssh-keygen -m PEM -t rsa -b 4096
   ```
 
-2. Add public key to EC2 instance
-Login to AWS and go to the EC2 console. Click "Instances" on the
+### **Add public key to EC2 instance**
+   
+Login to AWS and go to the EC2 console. Click *Instances* on the
 left nav panel.
 
 Select the instance you want to connect to by clicking the
-checkbox next to the instance name. Then, click "Connect" and select
-the "EC2 Instance Connect" tab. For the connection type select
-"Connect using EC2 Instance Connect" and leave the username as the
+checkbox next to the instance name. Then, click *Connect* and select
+the *EC2 Instance Connect* tab. For the connection type select
+*Connect using EC2 Instance Connect* and leave the username as the
 default `ec2-user`.
 
-Click "Connect" at the bottom of the page and a terminal will open
+Click *Connect* at the bottom of the page and a terminal will open
 connected to the EC2 instance in the ec2-user's home directory.
 
 Add the public key of your new key pair to the file
@@ -169,32 +174,32 @@ private key from your key pair.
 ssh -i <path-to-private-key> ec2-user@<hostname-or-ip-of-instance>
 ```
 
-3. Configure pgadmin
+### **Configure pgadmin**
+   
 With the pgadmin container running via `docker compose`, login to
-pgadmin at `http://localhost:8080/`.
+pgadmin at [localhost:8080](http://localhost:8080/).
 
-Click "Add New Server".
+Click *Add New Server*.
 
 Set the name of the server to something meaningful like
-'garden_db_dev', then click the 'Connection' tab.
+'garden_db_dev', then select the *Connection* tab.
 
-In the 'Host name/address' field add the private hostname or IP of the
+In the *Host name/address* field add the private hostname or IP of the
 RDS instance you want to connect to. This can be found in the AWS
-RDS console by clicking the instance and looking at the 'Connectivity
-& Security' tab.
+RDS console by clicking the instance and looking at the *Connectivity
+& Security* tab.
 
 Keep the port and username set with their default values.
 
-Move to the 'SSH Tunnel' tab of the server configuration and toggle
-'Use SSH tunneling' on.
+Move to the *SSH Tunnel* tab of the server configuration and toggle
+*Use SSH tunneling* on.
 
-'Tunnel host' should be the public hostname or IP of the EC2 instance.
-'Tunnel port' should be '22'
-'Username' should be 'ec2-user'
+*Tunnel host* should be the public hostname or IP of the EC2 instance.
+*Tunnel port* should be `22`
+*Username* should be `ec2-user`
+For *Authentication*, select *Identity file*
 
-For 'Authentication' select 'Identity file'
-
-The 'Identity file' should be the private key from your key
+The *Identity file* should be the private key from your key
 pair. Click the folder icon and select the private key file. Since
 pgadmin is running in a container you will need to upload your private
 key file before you can select it here. Click the three dots in the
@@ -202,7 +207,5 @@ upper right side of the file browser and select upload. Add the
 private key file from you key pair. Once the file is uploaded to the
 container, you can select it.
 
-Click 'Save' and if everything goes well pgadmin should connect to the
+Click *Save* and if everything goes well pgadmin should connect to the
 RDS instance using the EC2 instance as an ssh tunnel.
-
-4. Profit

--- a/garden-backend-service/README.md
+++ b/garden-backend-service/README.md
@@ -121,12 +121,12 @@ On a push to `dev` or `prod` branches, we run a GitHub action to build and push 
 use the same key pair for both instances.
 
 ### **Create ssh key pair**
-   
+
 Either through the AWS console or on the command line create an RSA
 keypair.
 
 - **Option 1 AWS Console**
-  
+
   Login to AWS and navigate to the EC2 Console. On the left nav panel
   under network and security select *Key Pairs*.
 
@@ -140,15 +140,15 @@ keypair.
   need to create a new one.
 
 - **Option 2 local command line**
-  
+
   Use `ssh-keygen` to generate a key pair locally:
-  
+
   ```sh
   ssh-keygen -m PEM -t rsa -b 4096
   ```
 
 ### **Add public key to EC2 instance**
-   
+
 Login to AWS and go to the EC2 console. Click *Instances* on the
 left nav panel.
 
@@ -156,7 +156,7 @@ Select the instance you want to connect to by clicking the
 checkbox next to the instance name. Then, click *Connect* and select
 the *EC2 Instance Connect* tab. For the connection type select
 *Connect using EC2 Instance Connect* and leave the username as the
-default `ec2-user`.
+default `ubuntu`.
 
 Click *Connect* at the bottom of the page and a terminal will open
 connected to the EC2 instance in the ec2-user's home directory.
@@ -171,11 +171,11 @@ You now have the ability to login to the instance with ssh using the
 private key from your key pair.
 
 ``` sh
-ssh -i <path-to-private-key> ec2-user@<hostname-or-ip-of-instance>
+ssh -i <path-to-private-key> ubuntu@<hostname-or-ip-of-instance>
 ```
 
 ### **Configure pgadmin**
-   
+
 With the pgadmin container running via `docker compose`, login to
 pgadmin at [localhost:8080](http://localhost:8080/).
 
@@ -184,19 +184,16 @@ Click *Add New Server*.
 Set the name of the server to something meaningful like
 'garden_db_dev', then select the *Connection* tab.
 
-In the *Host name/address* field add the private hostname or IP of the
-RDS instance you want to connect to. This can be found in the AWS
-RDS console by clicking the instance and looking at the *Connectivity
-& Security* tab.
+For the *Host name/address*, *username* and *password* fields, check the `garden-backend-env-vars/{dev, prod}`AWS secret and copy the appropriate values (`DB_ENDPOINT`/ `DB_USERNAME`/`DB_PASSWORD`, respectively).
 
-Keep the port and username set with their default values.
+Keep the *port* and *maintenance database* set with their default values.
 
 Move to the *SSH Tunnel* tab of the server configuration and toggle
 *Use SSH tunneling* on.
 
 *Tunnel host* should be the public hostname or IP of the EC2 instance.
 *Tunnel port* should be `22`
-*Username* should be `ec2-user`
+*Username* should be `ubuntu`
 For *Authentication*, select *Identity file*
 
 The *Identity file* should be the private key from your key

--- a/garden-backend-service/README.md
+++ b/garden-backend-service/README.md
@@ -113,3 +113,96 @@ docker compose up
 
 ## Deployments
 On a push to `dev` or `prod` branches, we run a GitHub action to build and push to the official (and public) `gardenai/garden-service:latest` dockerhub repo, which lightsail then pulls down for the deployment. Logs etc are visible through the [lightsail page](https://lightsail.aws.amazon.com/ls/webapp/home/containers). Note that we don't have any actual "lightsail instances", just a lightsail container service so you'll need to be on the "containers" page to see the logs.
+
+
+## Connect pgadmin to RDS instances
+
+Note: You will need to follow this process for each instance. You can
+use the same key pair for both instances.
+
+1. Create ssh key pair
+Either through the AWS console or on the command line create an RSA
+keypair.
+
+- Option 1 AWS Console
+  Login to AWS and navigate to the EC2 Console. On the left nav panel
+  under network and security select 'Key Pairs'.
+
+  Click 'Create key pair'.
+
+  Select "RSA" for the key pair type and select '.pem' for the format.
+
+  Create the key pair by clicking 'Create key pair' at the bottom of
+  the page. Make sure to download the generated key pair as this is
+  the only opportunity you have to save it. If you lose it you will
+  need to create a new one.
+
+- Option 2 local command line
+  Use `ssh-keygen` to generate a key pair locally:
+  ```sh
+  ssh-keygen -m PEM -t rsa -b 4096
+  ```
+
+2. Add public key to EC2 instance
+Login to AWS and go to the EC2 console. Click "Instances" on the
+left nav panel.
+
+Select the instance you want to connect to by clicking the
+checkbox next to the instance name. Then, click "Connect" and select
+the "EC2 Instance Connect" tab. For the connection type select
+"Connect using EC2 Instance Connect" and leave the username as the
+default `ec2-user`.
+
+Click "Connect" at the bottom of the page and a terminal will open
+connected to the EC2 instance in the ec2-user's home directory.
+
+Add the public key of your new key pair to the file
+`~/.ssh/authorized_keys`.
+
+``` sh
+echo "<public-key>" >> .ssh/authorized_keys
+```
+You now have the ability to login to the instance with ssh using the
+private key from your key pair.
+
+``` sh
+ssh -i <path-to-private-key> ec2-user@<hostname-or-ip-of-instance>
+```
+
+3. Configure pgadmin
+With the pgadmin container running via `docker compose`, login to
+pgadmin at `http://localhost:8080/`.
+
+Click "Add New Server".
+
+Set the name of the server to something meaningful like
+'garden_db_dev', then click the 'Connection' tab.
+
+In the 'Host name/address' field add the private hostname or IP of the
+RDS instance you want to connect to. This can be found in the AWS
+RDS console by clicking the instance and looking at the 'Connectivity
+& Security' tab.
+
+Keep the port and username set with their default values.
+
+Move to the 'SSH Tunnel' tab of the server configuration and toggle
+'Use SSH tunneling' on.
+
+'Tunnel host' should be the public hostname or IP of the EC2 instance.
+'Tunnel port' should be '22'
+'Username' should be 'ec2-user'
+
+For 'Authentication' select 'Identity file'
+
+The 'Identity file' should be the private key from your key
+pair. Click the folder icon and select the private key file. Since
+pgadmin is running in a container you will need to upload your private
+key file before you can select it here. Click the three dots in the
+upper right side of the file browser and select upload. Add the
+private key file from you key pair. Once the file is uploaded to the
+container, you can select it.
+
+Click 'Save' and if everything goes well pgadmin should connect to the
+RDS instance using the EC2 instance as an ssh tunnel.
+
+4. Profit

--- a/infra/dev/.terraform.lock.hcl
+++ b/infra/dev/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.42.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:Gwe5HXZYD/3M5j6LwKhp8amb1SraCR9p+G96d381RVc=",
     "h1:Yxsj34z606m8wssYDHyleuBlQ9i+94MHwRs38thQPZU=",
     "zh:0fb12bd56a3ad777b29f957c56dd2119776dbc01b6074458f597990e368c82de",
     "zh:16e99c13bef6e3777f67c240c916f57c01c9c142254cfb2720e08281ff906447",

--- a/infra/dev/outputs.tf
+++ b/infra/dev/outputs.tf
@@ -17,7 +17,7 @@ output "container_service_url" {
 
 output "api_endpoint_url" {
   description = "The full URL for the API endpoint"
-  value = "https://${var.subdomain_prefix}.${var.root_domain_name}"
+  value       = "https://${var.subdomain_prefix}.${var.root_domain_name}"
 }
 
 output "db_endpoint" {

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -83,7 +83,7 @@ data "aws_ami" "ubuntu" {
 
 # Create a security group for incoming ssh connections
 resource "aws_security_group" "bastion_sg" {
-  name = "garden_db_bastion_sg"
+  name = "garden_db_bastion_sg_${var.env}"
 
   # Accept incoming traffic on port 22
   ingress {
@@ -109,7 +109,7 @@ resource "aws_security_group" "bastion_sg" {
 
 
 # Provision the EC2 instance
-resource "aws_instance" "rds-bastion" {
+resource "aws_instance" "rds_bastion" {
   ami                         = data.aws_ami.ubuntu.id
   instance_type               = "t2.micro"
   associate_public_ip_address = true
@@ -129,6 +129,6 @@ resource "aws_security_group_rule" "bastion_to_rds" {
   from_port         = 5432
   to_port           = 5432
   protocol          = "tcp"
-  cidr_blocks       = ["${aws_instance.rds-bastion.private_ip}/32"]
+  cidr_blocks       = ["${aws_instance.rds_bastion.private_ip}/32"]
   security_group_id = aws_security_group.garden_db_sg.id
 }

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -97,7 +97,7 @@ resource "aws_security_group" "bastion_sg" {
   egress {
     from_port   = 0
     to_port     = 5432
-    protocol    = "-1"
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -2,6 +2,7 @@ data "aws_vpc" "default" {
   default = true
 }
 
+
 # security group for rds in default vpc
 # allowing connections from lightsail container(s)
 resource "aws_security_group" "garden_db_sg" {
@@ -27,12 +28,14 @@ resource "aws_security_group" "garden_db_sg" {
 
   tags = {
     Environment = var.env
+    Project     = "Garden"
   }
 
   lifecycle {
     create_before_destroy = true
   }
 }
+
 
 # provision the RDS instance
 resource "aws_db_instance" "garden_db" {
@@ -55,5 +58,77 @@ resource "aws_db_instance" "garden_db" {
 
   tags = {
     Environment = var.env
+    Project     = "Garden"
   }
+}
+
+
+# Lookup ubuntu ami
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+
+# Create a security group for incoming ssh connections
+resource "aws_security_group" "bastion_sg" {
+  name = "garden_db_bastion_sg"
+
+  # Accept incoming traffic on port 22
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outgoing traffic to port 5432
+  egress {
+    from_port   = 0
+    to_port     = 5432
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Environment = var.env
+    Project     = "Garden"
+  }
+}
+
+
+# Provision the EC2 instance
+resource "aws_instance" "rds-bastion" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = "t2.micro"
+  associate_public_ip_address = true
+  vpc_security_group_ids      = [aws_security_group.bastion_sg.id]
+
+  tags = {
+    Environment = var.env
+    Name        = "rds_bastion_${var.env}"
+    Project     = "Garden"
+  }
+}
+
+
+# Add the bastion host's private IP to the RDS security group ingress
+resource "aws_security_group_rule" "bastion_to_rds" {
+  type              = "ingress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = ["${aws_instance.rds-bastion.private_ip}/32"]
+  security_group_id = aws_security_group.garden_db_sg.id
 }

--- a/infra/modules/rds/outputs.tf
+++ b/infra/modules/rds/outputs.tf
@@ -15,5 +15,5 @@ output "db_security_group_id" {
 
 output "bastion_public_ip" {
   description = "The public IP address of the bastion EC2 instance."
-  value       = aws_instance.rds-bastion.public_ip
+  value       = aws_instance.rds_bastion.public_ip
 }

--- a/infra/modules/rds/outputs.tf
+++ b/infra/modules/rds/outputs.tf
@@ -12,3 +12,8 @@ output "db_security_group_id" {
   description = "The security group ID for the RDS instance."
   value       = aws_security_group.garden_db_sg.id
 }
+
+output "bastion_public_ip" {
+  description = "The public IP address of the bastion EC2 instance."
+  value       = aws_instance.rds-bastion.public_ip
+}

--- a/infra/prod/.terraform.lock.hcl
+++ b/infra/prod/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.42.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:Gwe5HXZYD/3M5j6LwKhp8amb1SraCR9p+G96d381RVc=",
     "h1:Yxsj34z606m8wssYDHyleuBlQ9i+94MHwRs38thQPZU=",
     "zh:0fb12bd56a3ad777b29f957c56dd2119776dbc01b6074458f597990e368c82de",
     "zh:16e99c13bef6e3777f67c240c916f57c01c9c142254cfb2720e08281ff906447",


### PR DESCRIPTION
Resolves: #102 

Starts resolving: #52 -- added `Project = "Garden"` to resource tags in the `rds` module.

## Overview

This PR adds resources to the `rds` Terraform module that provision an EC2 instance that can communicate with the RDS instance and act as an ssh tunnel allowing a local pgadmin to connect with the RDS instance.

## Discussion

This setup requires ssh keys to be added to the EC2 instance manually. I have included instructions on how to do that and how to configure pgadmin in `README.md`.

## Testing
Tested manually in my personal AWS account using a similar setup.

`terraform plan` looks correct against the current dev terraform state.