### PR TITLE
Deprecate '/garden-search-record' routes, keep search index in sync with db

### DIFF
--- a/garden-backend-service/poetry.lock
+++ b/garden-backend-service/poetry.lock
@@ -229,6 +229,7 @@ files = [
 
 [package.dependencies]
 botocore = ">=1.34.143,<1.35.0"
+
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -2216,13 +2217,22 @@ typing-extensions = ">=4.7.1"
 
 [[package]]
 name = "setuptools"
+<<<<<<< HEAD
 version = "70.3.0"
+=======
+version = "70.2.0"
+>>>>>>> 63d397a (Add logic to keep the search index in sync with our database)
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
+<<<<<<< HEAD
     {file = "setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"},
     {file = "setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"},
+=======
+    {file = "setuptools-70.2.0-py3-none-any.whl", hash = "sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05"},
+    {file = "setuptools-70.2.0.tar.gz", hash = "sha256:bd63e505105011b25c3c11f753f7e3b8465ea739efddaccef8f0efac2137bac1"},
+>>>>>>> 63d397a (Add logic to keep the search index in sync with our database)
 ]
 
 [package.extras]

--- a/garden-backend-service/poetry.lock
+++ b/garden-backend-service/poetry.lock
@@ -229,7 +229,6 @@ files = [
 
 [package.dependencies]
 botocore = ">=1.34.143,<1.35.0"
-
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -478,63 +477,63 @@ files = [
 
 [[package]]
 name = "coverage"
-version = "7.5.4"
+version = "7.6.0"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "coverage-7.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6cfb5a4f556bb51aba274588200a46e4dd6b505fb1a5f8c5ae408222eb416f99"},
-    {file = "coverage-7.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2174e7c23e0a454ffe12267a10732c273243b4f2d50d07544a91198f05c48f47"},
-    {file = "coverage-7.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2214ee920787d85db1b6a0bd9da5f8503ccc8fcd5814d90796c2f2493a2f4d2e"},
-    {file = "coverage-7.5.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1137f46adb28e3813dec8c01fefadcb8c614f33576f672962e323b5128d9a68d"},
-    {file = "coverage-7.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b385d49609f8e9efc885790a5a0e89f2e3ae042cdf12958b6034cc442de428d3"},
-    {file = "coverage-7.5.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b4a474f799456e0eb46d78ab07303286a84a3140e9700b9e154cfebc8f527016"},
-    {file = "coverage-7.5.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5cd64adedf3be66f8ccee418473c2916492d53cbafbfcff851cbec5a8454b136"},
-    {file = "coverage-7.5.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e564c2cf45d2f44a9da56f4e3a26b2236504a496eb4cb0ca7221cd4cc7a9aca9"},
-    {file = "coverage-7.5.4-cp310-cp310-win32.whl", hash = "sha256:7076b4b3a5f6d2b5d7f1185fde25b1e54eb66e647a1dfef0e2c2bfaf9b4c88c8"},
-    {file = "coverage-7.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:018a12985185038a5b2bcafab04ab833a9a0f2c59995b3cec07e10074c78635f"},
-    {file = "coverage-7.5.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:db14f552ac38f10758ad14dd7b983dbab424e731588d300c7db25b6f89e335b5"},
-    {file = "coverage-7.5.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3257fdd8e574805f27bb5342b77bc65578e98cbc004a92232106344053f319ba"},
-    {file = "coverage-7.5.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a6612c99081d8d6134005b1354191e103ec9705d7ba2754e848211ac8cacc6b"},
-    {file = "coverage-7.5.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d45d3cbd94159c468b9b8c5a556e3f6b81a8d1af2a92b77320e887c3e7a5d080"},
-    {file = "coverage-7.5.4-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed550e7442f278af76d9d65af48069f1fb84c9f745ae249c1a183c1e9d1b025c"},
-    {file = "coverage-7.5.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7a892be37ca35eb5019ec85402c3371b0f7cda5ab5056023a7f13da0961e60da"},
-    {file = "coverage-7.5.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8192794d120167e2a64721d88dbd688584675e86e15d0569599257566dec9bf0"},
-    {file = "coverage-7.5.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:820bc841faa502e727a48311948e0461132a9c8baa42f6b2b84a29ced24cc078"},
-    {file = "coverage-7.5.4-cp311-cp311-win32.whl", hash = "sha256:6aae5cce399a0f065da65c7bb1e8abd5c7a3043da9dceb429ebe1b289bc07806"},
-    {file = "coverage-7.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:d2e344d6adc8ef81c5a233d3a57b3c7d5181f40e79e05e1c143da143ccb6377d"},
-    {file = "coverage-7.5.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:54317c2b806354cbb2dc7ac27e2b93f97096912cc16b18289c5d4e44fc663233"},
-    {file = "coverage-7.5.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:042183de01f8b6d531e10c197f7f0315a61e8d805ab29c5f7b51a01d62782747"},
-    {file = "coverage-7.5.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6bb74ed465d5fb204b2ec41d79bcd28afccf817de721e8a807d5141c3426638"},
-    {file = "coverage-7.5.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3d45ff86efb129c599a3b287ae2e44c1e281ae0f9a9bad0edc202179bcc3a2e"},
-    {file = "coverage-7.5.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5013ed890dc917cef2c9f765c4c6a8ae9df983cd60dbb635df8ed9f4ebc9f555"},
-    {file = "coverage-7.5.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1014fbf665fef86cdfd6cb5b7371496ce35e4d2a00cda501cf9f5b9e6fced69f"},
-    {file = "coverage-7.5.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3684bc2ff328f935981847082ba4fdc950d58906a40eafa93510d1b54c08a66c"},
-    {file = "coverage-7.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:581ea96f92bf71a5ec0974001f900db495488434a6928a2ca7f01eee20c23805"},
-    {file = "coverage-7.5.4-cp312-cp312-win32.whl", hash = "sha256:73ca8fbc5bc622e54627314c1a6f1dfdd8db69788f3443e752c215f29fa87a0b"},
-    {file = "coverage-7.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:cef4649ec906ea7ea5e9e796e68b987f83fa9a718514fe147f538cfeda76d7a7"},
-    {file = "coverage-7.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cdd31315fc20868c194130de9ee6bfd99755cc9565edff98ecc12585b90be882"},
-    {file = "coverage-7.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:02ff6e898197cc1e9fa375581382b72498eb2e6d5fc0b53f03e496cfee3fac6d"},
-    {file = "coverage-7.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d05c16cf4b4c2fc880cb12ba4c9b526e9e5d5bb1d81313d4d732a5b9fe2b9d53"},
-    {file = "coverage-7.5.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5986ee7ea0795a4095ac4d113cbb3448601efca7f158ec7f7087a6c705304e4"},
-    {file = "coverage-7.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5df54843b88901fdc2f598ac06737f03d71168fd1175728054c8f5a2739ac3e4"},
-    {file = "coverage-7.5.4-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:ab73b35e8d109bffbda9a3e91c64e29fe26e03e49addf5b43d85fc426dde11f9"},
-    {file = "coverage-7.5.4-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:aea072a941b033813f5e4814541fc265a5c12ed9720daef11ca516aeacd3bd7f"},
-    {file = "coverage-7.5.4-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:16852febd96acd953b0d55fc842ce2dac1710f26729b31c80b940b9afcd9896f"},
-    {file = "coverage-7.5.4-cp38-cp38-win32.whl", hash = "sha256:8f894208794b164e6bd4bba61fc98bf6b06be4d390cf2daacfa6eca0a6d2bb4f"},
-    {file = "coverage-7.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:e2afe743289273209c992075a5a4913e8d007d569a406ffed0bd080ea02b0633"},
-    {file = "coverage-7.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b95c3a8cb0463ba9f77383d0fa8c9194cf91f64445a63fc26fb2327e1e1eb088"},
-    {file = "coverage-7.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3d7564cc09dd91b5a6001754a5b3c6ecc4aba6323baf33a12bd751036c998be4"},
-    {file = "coverage-7.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44da56a2589b684813f86d07597fdf8a9c6ce77f58976727329272f5a01f99f7"},
-    {file = "coverage-7.5.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e16f3d6b491c48c5ae726308e6ab1e18ee830b4cdd6913f2d7f77354b33f91c8"},
-    {file = "coverage-7.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbc5958cb471e5a5af41b0ddaea96a37e74ed289535e8deca404811f6cb0bc3d"},
-    {file = "coverage-7.5.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a04e990a2a41740b02d6182b498ee9796cf60eefe40cf859b016650147908029"},
-    {file = "coverage-7.5.4-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:ddbd2f9713a79e8e7242d7c51f1929611e991d855f414ca9996c20e44a895f7c"},
-    {file = "coverage-7.5.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b1ccf5e728ccf83acd313c89f07c22d70d6c375a9c6f339233dcf792094bcbf7"},
-    {file = "coverage-7.5.4-cp39-cp39-win32.whl", hash = "sha256:56b4eafa21c6c175b3ede004ca12c653a88b6f922494b023aeb1e836df953ace"},
-    {file = "coverage-7.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:65e528e2e921ba8fd67d9055e6b9f9e34b21ebd6768ae1c1723f4ea6ace1234d"},
-    {file = "coverage-7.5.4-pp38.pp39.pp310-none-any.whl", hash = "sha256:79b356f3dd5b26f3ad23b35c75dbdaf1f9e2450b6bcefc6d0825ea0aa3f86ca5"},
-    {file = "coverage-7.5.4.tar.gz", hash = "sha256:a44963520b069e12789d0faea4e9fdb1e410cdc4aab89d94f7f55cbb7fef0353"},
+    {file = "coverage-7.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dff044f661f59dace805eedb4a7404c573b6ff0cdba4a524141bc63d7be5c7fd"},
+    {file = "coverage-7.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a8659fd33ee9e6ca03950cfdcdf271d645cf681609153f218826dd9805ab585c"},
+    {file = "coverage-7.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7792f0ab20df8071d669d929c75c97fecfa6bcab82c10ee4adb91c7a54055463"},
+    {file = "coverage-7.6.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4b3cd1ca7cd73d229487fa5caca9e4bc1f0bca96526b922d61053ea751fe791"},
+    {file = "coverage-7.6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7e128f85c0b419907d1f38e616c4f1e9f1d1b37a7949f44df9a73d5da5cd53c"},
+    {file = "coverage-7.6.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a94925102c89247530ae1dab7dc02c690942566f22e189cbd53579b0693c0783"},
+    {file = "coverage-7.6.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:dcd070b5b585b50e6617e8972f3fbbee786afca71b1936ac06257f7e178f00f6"},
+    {file = "coverage-7.6.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d50a252b23b9b4dfeefc1f663c568a221092cbaded20a05a11665d0dbec9b8fb"},
+    {file = "coverage-7.6.0-cp310-cp310-win32.whl", hash = "sha256:0e7b27d04131c46e6894f23a4ae186a6a2207209a05df5b6ad4caee6d54a222c"},
+    {file = "coverage-7.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:54dece71673b3187c86226c3ca793c5f891f9fc3d8aa183f2e3653da18566169"},
+    {file = "coverage-7.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c7b525ab52ce18c57ae232ba6f7010297a87ced82a2383b1afd238849c1ff933"},
+    {file = "coverage-7.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bea27c4269234e06f621f3fac3925f56ff34bc14521484b8f66a580aacc2e7d"},
+    {file = "coverage-7.6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed8d1d1821ba5fc88d4a4f45387b65de52382fa3ef1f0115a4f7a20cdfab0e94"},
+    {file = "coverage-7.6.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01c322ef2bbe15057bc4bf132b525b7e3f7206f071799eb8aa6ad1940bcf5fb1"},
+    {file = "coverage-7.6.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03cafe82c1b32b770a29fd6de923625ccac3185a54a5e66606da26d105f37dac"},
+    {file = "coverage-7.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0d1b923fc4a40c5832be4f35a5dab0e5ff89cddf83bb4174499e02ea089daf57"},
+    {file = "coverage-7.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4b03741e70fb811d1a9a1d75355cf391f274ed85847f4b78e35459899f57af4d"},
+    {file = "coverage-7.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a73d18625f6a8a1cbb11eadc1d03929f9510f4131879288e3f7922097a429f63"},
+    {file = "coverage-7.6.0-cp311-cp311-win32.whl", hash = "sha256:65fa405b837060db569a61ec368b74688f429b32fa47a8929a7a2f9b47183713"},
+    {file = "coverage-7.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:6379688fb4cfa921ae349c76eb1a9ab26b65f32b03d46bb0eed841fd4cb6afb1"},
+    {file = "coverage-7.6.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f7db0b6ae1f96ae41afe626095149ecd1b212b424626175a6633c2999eaad45b"},
+    {file = "coverage-7.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bbdf9a72403110a3bdae77948b8011f644571311c2fb35ee15f0f10a8fc082e8"},
+    {file = "coverage-7.6.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc44bf0315268e253bf563f3560e6c004efe38f76db03a1558274a6e04bf5d5"},
+    {file = "coverage-7.6.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:da8549d17489cd52f85a9829d0e1d91059359b3c54a26f28bec2c5d369524807"},
+    {file = "coverage-7.6.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0086cd4fc71b7d485ac93ca4239c8f75732c2ae3ba83f6be1c9be59d9e2c6382"},
+    {file = "coverage-7.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1fad32ee9b27350687035cb5fdf9145bc9cf0a094a9577d43e909948ebcfa27b"},
+    {file = "coverage-7.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:044a0985a4f25b335882b0966625270a8d9db3d3409ddc49a4eb00b0ef5e8cee"},
+    {file = "coverage-7.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:76d5f82213aa78098b9b964ea89de4617e70e0d43e97900c2778a50856dac605"},
+    {file = "coverage-7.6.0-cp312-cp312-win32.whl", hash = "sha256:3c59105f8d58ce500f348c5b56163a4113a440dad6daa2294b5052a10db866da"},
+    {file = "coverage-7.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:ca5d79cfdae420a1d52bf177de4bc2289c321d6c961ae321503b2ca59c17ae67"},
+    {file = "coverage-7.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d39bd10f0ae453554798b125d2f39884290c480f56e8a02ba7a6ed552005243b"},
+    {file = "coverage-7.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:beb08e8508e53a568811016e59f3234d29c2583f6b6e28572f0954a6b4f7e03d"},
+    {file = "coverage-7.6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2e16f4cd2bc4d88ba30ca2d3bbf2f21f00f382cf4e1ce3b1ddc96c634bc48ca"},
+    {file = "coverage-7.6.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6616d1c9bf1e3faea78711ee42a8b972367d82ceae233ec0ac61cc7fec09fa6b"},
+    {file = "coverage-7.6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad4567d6c334c46046d1c4c20024de2a1c3abc626817ae21ae3da600f5779b44"},
+    {file = "coverage-7.6.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d17c6a415d68cfe1091d3296ba5749d3d8696e42c37fca5d4860c5bf7b729f03"},
+    {file = "coverage-7.6.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:9146579352d7b5f6412735d0f203bbd8d00113a680b66565e205bc605ef81bc6"},
+    {file = "coverage-7.6.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:cdab02a0a941af190df8782aafc591ef3ad08824f97850b015c8c6a8b3877b0b"},
+    {file = "coverage-7.6.0-cp38-cp38-win32.whl", hash = "sha256:df423f351b162a702c053d5dddc0fc0ef9a9e27ea3f449781ace5f906b664428"},
+    {file = "coverage-7.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:f2501d60d7497fd55e391f423f965bbe9e650e9ffc3c627d5f0ac516026000b8"},
+    {file = "coverage-7.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7221f9ac9dad9492cecab6f676b3eaf9185141539d5c9689d13fd6b0d7de840c"},
+    {file = "coverage-7.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ddaaa91bfc4477d2871442bbf30a125e8fe6b05da8a0015507bfbf4718228ab2"},
+    {file = "coverage-7.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4cbe651f3904e28f3a55d6f371203049034b4ddbce65a54527a3f189ca3b390"},
+    {file = "coverage-7.6.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:831b476d79408ab6ccfadaaf199906c833f02fdb32c9ab907b1d4aa0713cfa3b"},
+    {file = "coverage-7.6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46c3d091059ad0b9c59d1034de74a7f36dcfa7f6d3bde782c49deb42438f2450"},
+    {file = "coverage-7.6.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4d5fae0a22dc86259dee66f2cc6c1d3e490c4a1214d7daa2a93d07491c5c04b6"},
+    {file = "coverage-7.6.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:07ed352205574aad067482e53dd606926afebcb5590653121063fbf4e2175166"},
+    {file = "coverage-7.6.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:49c76cdfa13015c4560702574bad67f0e15ca5a2872c6a125f6327ead2b731dd"},
+    {file = "coverage-7.6.0-cp39-cp39-win32.whl", hash = "sha256:482855914928c8175735a2a59c8dc5806cf7d8f032e4820d52e845d1f731dca2"},
+    {file = "coverage-7.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:543ef9179bc55edfd895154a51792b01c017c87af0ebaae092720152e19e42ca"},
+    {file = "coverage-7.6.0-pp38.pp39.pp310-none-any.whl", hash = "sha256:6fe885135c8a479d3e37a7aae61cbd3a0fb2deccb4dda3c25f92a49189f766d6"},
+    {file = "coverage-7.6.0.tar.gz", hash = "sha256:289cc803fa1dc901f84701ac10c9ee873619320f2f9aff38794db4a4a0268d51"},
 ]
 
 [package.dependencies]
@@ -2217,22 +2216,13 @@ typing-extensions = ">=4.7.1"
 
 [[package]]
 name = "setuptools"
-<<<<<<< HEAD
 version = "70.3.0"
-=======
-version = "70.2.0"
->>>>>>> 63d397a (Add logic to keep the search index in sync with our database)
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-<<<<<<< HEAD
     {file = "setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"},
     {file = "setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"},
-=======
-    {file = "setuptools-70.2.0-py3-none-any.whl", hash = "sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05"},
-    {file = "setuptools-70.2.0.tar.gz", hash = "sha256:bd63e505105011b25c3c11f753f7e3b8465ea739efddaccef8f0efac2137bac1"},
->>>>>>> 63d397a (Add logic to keep the search index in sync with our database)
 ]
 
 [package.extras]

--- a/garden-backend-service/src/api/routes/_tasks.py
+++ b/garden-backend-service/src/api/routes/_tasks.py
@@ -1,25 +1,32 @@
 from src.api.dependencies.search import get_globus_search_client
 from src.auth.globus_auth import get_auth_client
 from src.config import Settings
+from src.models import Garden
 
-from ._utils import poll_globus_search_task
+from ._utils import _garden_sqlalchemy_to_pydantic, poll_globus_search_task
 
 
-async def delete_from_search_index(garden_data, settings: Settings):
+async def delete_from_search_index(garden: Garden, settings: Settings):
     client = get_globus_search_client(get_auth_client())
     delete_result = client.delete_entry(
         settings.GLOBUS_SEARCH_INDEX_ID,
-        garden_data.doi,
+        garden.doi,
     )
     task_id = delete_result["task_id"]
     return await poll_globus_search_task(task_id, client)
 
 
-async def create_or_update_on_search_index(garden_data, settings: Settings):
+async def create_or_update_on_search_index(garden: Garden, settings: Settings):
     client = get_globus_search_client(get_auth_client())
+    garden_pub = _garden_sqlalchemy_to_pydantic(garden)
+    garden_meta = {
+        "subject": garden_pub.doi,
+        "visible_to": ["public"],
+        "content": garden_pub.dict(),
+    }
     create_result = client.create_entry(
         settings.GLOBUS_SEARCH_INDEX_ID,
-        garden_data.doi,
+        garden_meta,
     )
     task_id = create_result["task_id"]
 

--- a/garden-backend-service/src/api/routes/_tasks.py
+++ b/garden-backend-service/src/api/routes/_tasks.py
@@ -1,0 +1,28 @@
+from src.api.dependencies.search import get_globus_search_client
+from src.auth.globus_auth import get_auth_client
+from src.config import Settings
+
+from ._utils import poll_globus_search_task
+
+
+async def delete_from_search_index(garden_data, settings: Settings):
+    if settings.SYNC_SEARCH_INDEX:
+        client = get_globus_search_client(get_auth_client())
+        delete_result = client.delete_entry(
+            settings.GLOBUS_SEARCH_INDEX_ID,
+            garden_data.doi,
+        )
+        task_id = delete_result["task_id"]
+        return await poll_globus_search_task(task_id, client)
+
+
+async def create_or_update_on_search_index(garden_data, settings: Settings):
+    if settings.SYNC_SEARCH_INDEX:
+        client = get_globus_search_client(get_auth_client())
+        create_result = client.create_entry(
+            settings.GLOBUS_SEARCH_INDEX_ID,
+            garden_data.doi,
+        )
+        task_id = create_result["task_id"]
+
+        return await poll_globus_search_task(task_id, client)

--- a/garden-backend-service/src/api/routes/_tasks.py
+++ b/garden-backend-service/src/api/routes/_tasks.py
@@ -6,23 +6,21 @@ from ._utils import poll_globus_search_task
 
 
 async def delete_from_search_index(garden_data, settings: Settings):
-    if settings.SYNC_SEARCH_INDEX:
-        client = get_globus_search_client(get_auth_client())
-        delete_result = client.delete_entry(
-            settings.GLOBUS_SEARCH_INDEX_ID,
-            garden_data.doi,
-        )
-        task_id = delete_result["task_id"]
-        return await poll_globus_search_task(task_id, client)
+    client = get_globus_search_client(get_auth_client())
+    delete_result = client.delete_entry(
+        settings.GLOBUS_SEARCH_INDEX_ID,
+        garden_data.doi,
+    )
+    task_id = delete_result["task_id"]
+    return await poll_globus_search_task(task_id, client)
 
 
 async def create_or_update_on_search_index(garden_data, settings: Settings):
-    if settings.SYNC_SEARCH_INDEX:
-        client = get_globus_search_client(get_auth_client())
-        create_result = client.create_entry(
-            settings.GLOBUS_SEARCH_INDEX_ID,
-            garden_data.doi,
-        )
-        task_id = create_result["task_id"]
+    client = get_globus_search_client(get_auth_client())
+    create_result = client.create_entry(
+        settings.GLOBUS_SEARCH_INDEX_ID,
+        garden_data.doi,
+    )
+    task_id = create_result["task_id"]
 
-        return await poll_globus_search_task(task_id, client)
+    return await poll_globus_search_task(task_id, client)

--- a/garden-backend-service/src/api/routes/_tasks.py
+++ b/garden-backend-service/src/api/routes/_tasks.py
@@ -1,9 +1,10 @@
 from src.api.dependencies.search import get_globus_search_client
+from src.api.schemas.search import PublishSearchRecordRequest
 from src.auth.globus_auth import get_auth_client
 from src.config import Settings
 from src.models import Garden
 
-from ._utils import _garden_sqlalchemy_to_pydantic, poll_globus_search_task
+from ._utils import poll_globus_search_task
 
 
 async def delete_from_search_index(garden: Garden, settings: Settings):
@@ -18,11 +19,11 @@ async def delete_from_search_index(garden: Garden, settings: Settings):
 
 async def create_or_update_on_search_index(garden: Garden, settings: Settings):
     client = get_globus_search_client(get_auth_client())
-    garden_pub = _garden_sqlalchemy_to_pydantic(garden)
+    garden_pub = PublishSearchRecordRequest.model_validate(garden, from_attributes=True)
     garden_meta = {
         "subject": garden_pub.doi,
         "visible_to": ["public"],
-        "content": garden_pub.dict(),
+        "content": garden_pub.model_dump(mode="json"),
     }
     create_result = client.create_entry(
         settings.GLOBUS_SEARCH_INDEX_ID,

--- a/garden-backend-service/src/api/routes/_utils.py
+++ b/garden-backend-service/src/api/routes/_utils.py
@@ -1,3 +1,5 @@
+import functools
+
 import httpx
 from fastapi import HTTPException, status
 from src.models import Entrypoint, Garden, User
@@ -44,3 +46,26 @@ async def is_doi_registered(doi: str) -> bool:
         return True
     else:
         return False
+
+
+def deprecated(
+    name="Endpoint",
+    message: str = None,
+    doc_url: str = "https://api-dev.thegardens.ai/docs",
+):
+    """Mark an endpoint as deprecated.
+
+    Causes the endpoint to return a 410 response with optional message and docs link.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            raise HTTPException(
+                status_code=status.HTTP_410_GONE,
+                detail=f"{name} is deprecated. {message if message is not None else ''} See: {doc_url}",
+            )
+
+        return wrapper
+
+    return decorator

--- a/garden-backend-service/src/api/routes/_utils.py
+++ b/garden-backend-service/src/api/routes/_utils.py
@@ -4,8 +4,6 @@ import functools
 import httpx
 from fastapi import HTTPException, exceptions, status
 from globus_sdk import SearchClient
-from src.api.dependencies.search import get_globus_search_client
-from src.auth.globus_auth import get_auth_client
 from src.models import Entrypoint, Garden, User
 
 
@@ -98,25 +96,3 @@ async def poll_globus_search_task(
         raise exceptions.HTTPException(
             status.HTTP_500_INTERNAL_SERVER_ERROR, detail=task_result.text
         )
-
-
-async def delete_from_search_index(garden_data, settings):
-    if settings.SYNC_SEARCH_INDEX:
-        client = get_globus_search_client(get_auth_client())
-        delete_result = client.delete_entry(
-            settings.GLOBUS_SEARCH_INDEX_ID,
-            garden_data.doi,
-        )
-        task_id = delete_result["task_id"]
-        return await poll_globus_search_task(task_id, client)
-
-
-async def create_or_update_on_search_index(garden_data, settings):
-    if settings.SYNC_SEARCH_INDEX:
-        client = get_globus_search_client(get_auth_client())
-        create_result = client.create_entry(
-            settings.GLOBUS_SEARCH_INDEX_ID,
-            garden_data.doi,
-        )
-        task_id = create_result["task_id"]
-        return await poll_globus_search_task(task_id, client)

--- a/garden-backend-service/src/api/routes/_utils.py
+++ b/garden-backend-service/src/api/routes/_utils.py
@@ -6,9 +6,6 @@ from fastapi import HTTPException, exceptions, status
 from globus_sdk import SearchClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from src.api.schemas.base import UniqueList
-from src.api.schemas.search import PublishSearchRecordRequest
-from src.api.schemas.search._garden_sdk_schema import _RegisteredEntrypoint
 from src.models import Entrypoint, Garden, User
 from src.models._associations import gardens_entrypoints
 
@@ -59,7 +56,7 @@ async def is_doi_registered(doi: str) -> bool:
 async def get_gardens_for_entrypoint(
     entrypoint: Entrypoint, db: AsyncSession
 ) -> list[Garden] | None:
-    garden_entrys = await db.execute(
+    garden_entrys = await db.scalars(
         select(Garden)
         .join(gardens_entrypoints, Garden.id == gardens_entrypoints.c.garden_id)
         .where(gardens_entrypoints.c.entrypoint_id == entrypoint.id)
@@ -113,26 +110,3 @@ async def poll_globus_search_task(
         raise exceptions.HTTPException(
             status.HTTP_500_INTERNAL_SERVER_ERROR, detail=task_result.text
         )
-
-
-def _garden_sqlalchemy_to_pydantic(garden: Garden):
-    entrypoints = [
-        _RegisteredEntrypoint(**entrypoint.__dict__)
-        for entrypoint in garden.entrypoints
-    ]
-
-    # Create and return the Pydantic model instance
-    return PublishSearchRecordRequest(
-        title=garden.title,
-        authors=garden.authors,
-        contributors=UniqueList(garden.contributors),
-        doi=garden.doi,
-        description=garden.description,
-        publisher=garden.publisher,
-        year=garden.year,
-        language=garden.language,
-        tags=UniqueList(garden.tags),
-        version=garden.version,
-        entrypoints=entrypoints,
-        entrypoint_aliases=garden.entrypoint_aliases,
-    )

--- a/garden-backend-service/src/api/routes/_utils.py
+++ b/garden-backend-service/src/api/routes/_utils.py
@@ -53,7 +53,7 @@ async def is_doi_registered(doi: str) -> bool:
 def deprecated(
     name="Endpoint",
     message: str = None,
-    doc_url: str = "https://api-dev.thegardens.ai/docs",
+    doc_url: str = "https://api.thegardens.ai/docs",
 ):
     """Mark an endpoint as deprecated.
 

--- a/garden-backend-service/src/api/routes/_utils.py
+++ b/garden-backend-service/src/api/routes/_utils.py
@@ -6,7 +6,6 @@ from fastapi import HTTPException, exceptions, status
 from globus_sdk import SearchClient
 from src.api.dependencies.search import get_globus_search_client
 from src.auth.globus_auth import get_auth_client
-from src.config import get_settings
 from src.models import Entrypoint, Garden, User
 
 
@@ -101,8 +100,7 @@ async def poll_globus_search_task(
         )
 
 
-async def delete_from_search_index(garden_data):
-    settings = get_settings()
+async def delete_from_search_index(garden_data, settings):
     if settings.SYNC_SEARCH_INDEX:
         client = get_globus_search_client(get_auth_client())
         delete_result = client.delete_entry(
@@ -113,8 +111,7 @@ async def delete_from_search_index(garden_data):
         return await poll_globus_search_task(task_id, client)
 
 
-async def create_or_update_on_search_index(garden_data):
-    settings = get_settings()
+async def create_or_update_on_search_index(garden_data, settings):
     if settings.SYNC_SEARCH_INDEX:
         client = get_globus_search_client(get_auth_client())
         create_result = client.create_entry(

--- a/garden-backend-service/src/api/routes/_utils.py
+++ b/garden-backend-service/src/api/routes/_utils.py
@@ -1,7 +1,12 @@
+import asyncio
 import functools
 
 import httpx
-from fastapi import HTTPException, status
+from fastapi import HTTPException, exceptions, status
+from globus_sdk import SearchClient
+from src.api.dependencies.search import get_globus_search_client
+from src.auth.globus_auth import get_auth_client
+from src.config import get_settings
 from src.models import Entrypoint, Garden, User
 
 
@@ -69,3 +74,52 @@ def deprecated(
         return wrapper
 
     return decorator
+
+
+async def poll_globus_search_task(
+    task_id, search_client: SearchClient, max_intervals=25
+):
+    task_result = search_client.get_task(task_id)
+    while task_result["state"] not in {"FAILED", "SUCCESS"}:
+        if max_intervals == 0:
+            raise exceptions.HTTPException(
+                status.HTTP_408_REQUEST_TIMEOUT,
+                detail=(
+                    "Server timed out waiting for globus search task to finish. "
+                    f"You can manually check its progress with the task id: {task_id}"
+                ),
+            )
+        await asyncio.sleep(0.2)
+        max_intervals -= 1
+        task_result = search_client.get_task(task_id)
+
+    if task_result["state"] == "SUCCESS":
+        return {}
+    else:
+        raise exceptions.HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, detail=task_result.text
+        )
+
+
+async def delete_from_search_index(garden_data):
+    settings = get_settings()
+    if settings.SYNC_SEARCH_INDEX:
+        client = get_globus_search_client(get_auth_client())
+        delete_result = client.delete_entry(
+            settings.GLOBUS_SEARCH_INDEX_ID,
+            garden_data.doi,
+        )
+        task_id = delete_result["task_id"]
+        return await poll_globus_search_task(task_id, client)
+
+
+async def create_or_update_on_search_index(garden_data):
+    settings = get_settings()
+    if settings.SYNC_SEARCH_INDEX:
+        client = get_globus_search_client(get_auth_client())
+        create_result = client.create_entry(
+            settings.GLOBUS_SEARCH_INDEX_ID,
+            garden_data.doi,
+        )
+        task_id = create_result["task_id"]
+        return await poll_globus_search_task(task_id, client)

--- a/garden-backend-service/src/api/routes/_utils.py
+++ b/garden-backend-service/src/api/routes/_utils.py
@@ -53,15 +53,15 @@ async def is_doi_registered(doi: str) -> bool:
         return False
 
 
-async def get_garden_for_entrypoint(
+async def get_gardens_for_entrypoint(
     entrypoint: Entrypoint, db: AsyncSession
-) -> Garden | None:
-    garden_entry = await db.execute(
+) -> list[Garden] | None:
+    garden_entrys = await db.execute(
         select(Garden)
         .join(gardens_entrypoints, Garden.id == gardens_entrypoints.c.garden_id)
         .where(gardens_entrypoints.c.entrypoint_id == entrypoint.id)
     )
-    return garden_entry.scalar_one_or_none()
+    return garden_entrys.all()
 
 
 def deprecated(

--- a/garden-backend-service/src/api/routes/entrypoints.py
+++ b/garden-backend-service/src/api/routes/entrypoints.py
@@ -70,6 +70,9 @@ async def delete_entrypoint(
                     db.refresh(garden)
                     if settings.SYNC_SEARCH_INDEX:
                         # just update the gardens, we don't want to delete a garden just because we deleted an entrypoint
+                        logger.info(
+                            msg=f"Deleting garden {garden.doi} from search index"
+                        )
                         background_tasks.add_task(
                             create_or_update_on_search_index, garden, settings
                         )
@@ -121,6 +124,7 @@ async def create_or_replace_entrypoint(
         )
         if gardens and settings.SYNC_SEARCH_INDEX:
             for garden in gardens:
+                logger.info(msg=f"Sending garden {garden.doi} to search index")
                 background_tasks.add_task(
                     create_or_update_on_search_index, garden, settings
                 )

--- a/garden-backend-service/src/api/routes/entrypoints.py
+++ b/garden-backend-service/src/api/routes/entrypoints.py
@@ -70,9 +70,7 @@ async def delete_entrypoint(
                     db.refresh(garden)
                     if settings.SYNC_SEARCH_INDEX:
                         # just update the gardens, we don't want to delete a garden just because we deleted an entrypoint
-                        logger.info(
-                            msg=f"Deleting garden {garden.doi} from search index"
-                        )
+                        logger.info(msg=f"Updating garden {garden.doi} on search index")
                         background_tasks.add_task(
                             create_or_update_on_search_index, garden, settings
                         )

--- a/garden-backend-service/src/api/routes/entrypoints.py
+++ b/garden-backend-service/src/api/routes/entrypoints.py
@@ -1,16 +1,18 @@
 from logging import getLogger
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.dependencies.auth import authed_user
 from src.api.dependencies.database import get_db_session
-from src.api.routes._utils import assert_deletable_by_user
+from src.api.routes._tasks import create_or_update_on_search_index
+from src.api.routes._utils import assert_deletable_by_user, get_garden_for_entrypoint
 from src.api.schemas.entrypoint import (
     EntrypointCreateRequest,
     EntrypointMetadataResponse,
 )
-from src.models import Entrypoint, User
+from src.config import Settings, get_settings
+from src.models import Entrypoint, Garden, User
 
 logger = getLogger(__name__)
 
@@ -50,16 +52,25 @@ async def get_entrypoint_by_doi(
 @router.delete("/{doi:path}", status_code=status.HTTP_200_OK)
 async def delete_entrypoint(
     doi: str,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db_session),
     user: User = Depends(authed_user),
+    settings: Settings = Depends(get_settings),
 ):
     entrypoint: Entrypoint | None = await Entrypoint.get(db, doi=doi)
 
     if entrypoint is not None:
         assert_deletable_by_user(entrypoint, user)
+        garden: Garden | None = await get_garden_for_entrypoint(entrypoint, db)
         await db.delete(entrypoint)
         try:
             await db.commit()
+            db.refresh(garden)
+            if garden and settings.SYNC_SEARCH_INDEX:
+                # just update the garden, we don't want to delete a garden just because we deleted an entrypoint
+                background_tasks.add_task(
+                    create_or_update_on_search_index, garden, settings
+                )
         except IntegrityError as e:
             await db.rollback()
             raise HTTPException(
@@ -76,9 +87,11 @@ async def delete_entrypoint(
 @router.put("/{doi:path}", response_model=EntrypointMetadataResponse)
 async def create_or_replace_entrypoint(
     doi: str,
+    background_tasks: BackgroundTasks,
     entrypoint_data: EntrypointCreateRequest,
     db: AsyncSession = Depends(get_db_session),
     user: User = Depends(authed_user),
+    settings: Settings = Depends(get_settings),
 ):
     existing_entrypoint: Entrypoint | None = await Entrypoint.get(db, doi=doi)
 
@@ -101,6 +114,11 @@ async def create_or_replace_entrypoint(
             setattr(existing_entrypoint, key, value)
 
         await db.commit()
+        garden: Garden | None = await get_garden_for_entrypoint(existing_entrypoint, db)
+        if garden and settings.SYNC_SEARCH_INDEX:
+            background_tasks.add_task(
+                create_or_update_on_search_index, garden, settings
+            )
     except IntegrityError as e:
         await db.rollback()
         raise HTTPException(

--- a/garden-backend-service/src/api/routes/garden_search_record.py
+++ b/garden-backend-service/src/api/routes/garden_search_record.py
@@ -13,7 +13,7 @@ router = APIRouter(prefix="/garden-search-record")
 @deprecated(
     name="/garden-search-record",
     message="Use /gardens instead or update garden-ai package to latest version.",
-    doc_url="https://api-dev.thegardens.ai/docs#/default/add_garden_gardens_post",
+    doc_url="https://api.thegardens.ai/docs#/default/add_garden_gardens_post",
 )
 async def publish_search_record(
     garden_meta: PublishSearchRecordRequest,
@@ -37,7 +37,7 @@ async def publish_search_record(
 @deprecated(
     name="/delete-search-record",
     message="Use /gardens instead or update garden-ai package to latest version.",
-    doc_url="https://api-dev.thegardens.ai/docs#/default/delete_garden_gardens__doi__delete",
+    doc_url="https://api.thegardens.ai/docs#/default/delete_garden_gardens__doi__delete",
 )
 async def delete_search_record(
     body: DeleteSearchRecordRequest,

--- a/garden-backend-service/src/api/routes/garden_search_record.py
+++ b/garden-backend-service/src/api/routes/garden_search_record.py
@@ -4,14 +4,19 @@ from fastapi import APIRouter, Depends, exceptions, status
 from globus_sdk import SearchClient
 from src.api.dependencies.auth import AuthenticationState, authenticated
 from src.api.dependencies.search import get_globus_search_client
-from src.api.routes._utils import is_doi_registered
+from src.api.routes._utils import deprecated, is_doi_registered
 from src.api.schemas.search import DeleteSearchRecordRequest, PublishSearchRecordRequest
 from src.config import Settings, get_settings
 
 router = APIRouter(prefix="/garden-search-record")
 
 
-@router.post("", status_code=status.HTTP_200_OK)
+@router.post("", status_code=status.HTTP_200_OK, deprecated=True)
+@deprecated(
+    name="/garden-search-record",
+    message="Use /gardens instead or update garden-ai package to latest version.",
+    doc_url="https://api-dev.thegardens.ai/docs#/default/add_garden_gardens_post",
+)
 async def publish_search_record(
     garden_meta: PublishSearchRecordRequest,
     settings: Settings = Depends(get_settings),
@@ -30,7 +35,12 @@ async def publish_search_record(
     return await _poll_globus_search_task(task_id, search_client)
 
 
-@router.delete("", status_code=status.HTTP_200_OK)
+@router.delete("", status_code=status.HTTP_200_OK, deprecated=True)
+@deprecated(
+    name="/delete-search-record",
+    message="Use /gardens instead or update garden-ai package to latest version.",
+    doc_url="https://api-dev.thegardens.ai/docs#/default/delete_garden_gardens__doi__delete",
+)
 async def delete_search_record(
     body: DeleteSearchRecordRequest,
     settings: Settings = Depends(get_settings),

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -6,12 +6,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.dependencies.auth import authed_user
 from src.api.dependencies.database import get_db_session
-from src.api.routes._utils import (
-    assert_deletable_by_user,
+from src.api.routes._tasks import (
     create_or_update_on_search_index,
     delete_from_search_index,
-    is_doi_registered,
 )
+from src.api.routes._utils import assert_deletable_by_user, is_doi_registered
 from src.api.schemas.garden import GardenCreateRequest, GardenMetadataResponse
 from src.config import Settings, get_settings
 from src.models import Entrypoint, Garden, User

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -29,6 +29,7 @@ async def add_garden(
 ):
     new_garden = await _create_new_garden(garden, db, user)
     if settings.SYNC_SEARCH_INDEX:
+        logger.info(msg=f"Sending garden {new_garden.doi} to search index")
         background_tasks.add_task(
             create_or_update_on_search_index, new_garden, settings
         )
@@ -68,6 +69,7 @@ async def delete_garden(
         try:
             await db.commit()
             if settings.SYNC_SEARCH_INDEX:
+                logger.info(msg=f"Deleting garden {garden.doi} from search index")
                 background_tasks.add_task(delete_from_search_index, garden, settings)
         except IntegrityError as e:
             await db.rollback()
@@ -93,6 +95,7 @@ async def create_or_replace_garden(
     if existing_garden is None:
         new_garden = await _create_new_garden(garden_data, db, user)
         if settings.SYNC_SEARCH_INDEX:
+            logger.log(msg=f"Sending garden {new_garden.doi} to search index")
             background_tasks.add_task(
                 create_or_update_on_search_index, new_garden, settings
             )
@@ -123,6 +126,7 @@ async def create_or_replace_garden(
     try:
         await db.commit()
         if settings.SYNC_SEARCH_INDEX:
+            logger.info(msg=f"Updating garden {existing_garden.doi} on search index")
             background_tasks.add_task(
                 create_or_update_on_search_index, existing_garden, settings
             )

--- a/garden-backend-service/src/api/schemas/base.py
+++ b/garden-backend-service/src/api/schemas/base.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List, TypeVar
+from typing import Annotated, TypeVar
 
 from pydantic import (
     AfterValidator,
@@ -43,7 +43,7 @@ def _validate_unique_list(v: list[T]) -> list[T]:
 
 
 UniqueList = Annotated[
-    List[T],
+    list[T],
     AfterValidator(_validate_unique_list),
     Field(json_schema_extra={"uniqueItems": True}, default_factory=list),
 ]

--- a/garden-backend-service/src/config.py
+++ b/garden-backend-service/src/config.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
     NOTEBOOKS_S3_BUCKET: str
 
     GLOBUS_SEARCH_INDEX_ID: str
+    SYNC_SEARCH_INDEX: bool
 
     DB_USERNAME: str
     DB_PASSWORD: str

--- a/garden-backend-service/tests/api/routes/test_gardens.py
+++ b/garden-backend-service/tests/api/routes/test_gardens.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -23,9 +22,7 @@ async def test_add_garden(
     create_entrypoint_with_related_metadata_json,
     create_shared_entrypoint_json,
     create_garden_two_entrypoints_json,
-    mocker,
 ):
-    mocker.patch("src.api.routes.gardens.BackgroundTasks", return_value=MagicMock())
     await post_entrypoints(
         client,
         create_shared_entrypoint_json,
@@ -155,7 +152,6 @@ async def test_put_updated_garden(
     )
     assert response.status_code == 200
     assert len(response.json()["entrypoints"]) == 2
-
     updated_payload = deepcopy(create_garden_two_entrypoints_json)
     updated_payload["title"] = "Updated Title"
     # only one of the DOIs this time

--- a/garden-backend-service/tests/api/routes/test_gardens.py
+++ b/garden-backend-service/tests/api/routes/test_gardens.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -22,7 +23,9 @@ async def test_add_garden(
     create_entrypoint_with_related_metadata_json,
     create_shared_entrypoint_json,
     create_garden_two_entrypoints_json,
+    mocker,
 ):
+    mocker.patch("src.api.routes.gardens.BackgroundTasks", return_value=MagicMock())
     await post_entrypoints(
         client,
         create_shared_entrypoint_json,

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -140,6 +140,7 @@ def mock_settings(db_url):
     mock_settings.SQLALCHEMY_DATABASE_URL = db_url
     mock_settings.GARDEN_USERS_GROUP_ID = "fakeid"
     mock_settings.SYNC_SEARCH_INDEX = False
+    mock_settings.GLOBUS_SEARCH_INDEX_ID = "GLOBUS_ID"
     return mock_settings
 
 

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -139,6 +139,7 @@ def mock_settings(db_url):
     mock_settings.NOTEBOOKS_S3_BUCKET = "test-bucket"
     mock_settings.SQLALCHEMY_DATABASE_URL = db_url
     mock_settings.GARDEN_USERS_GROUP_ID = "fakeid"
+    mock_settings.SYNC_SEARCH_INDEX = False
     return mock_settings
 
 


### PR DESCRIPTION
Resolves: #95, #112 

## Overview

This PR deprecates the `/garden-search-record` routes and adds logic to keep the search index in sync with our database.

## Discussion

I created a new `@deprecated` decorator we can add to routes that returns 410 status code and a helpful message to clients with an optional link to relevant docs. For example:
```
@router.post("", status_code=status.HTTP_200_OK, deprecated=True)
@deprecated(
    name="/garden-search-record",
    message="Use /gardens instead or update garden-ai package to latest version.",
    doc_url="https://api-dev.thegardens.ai/docs#/default/add_garden_gardens_post",
)
async def publish_search_record(
    garden_meta: PublishSearchRecordRequest,
    settings: Settings = Depends(get_settings),
    search_client: SearchClient = Depends(get_globus_search_client),
    _auth: AuthenticationState = Depends(authenticated),
):
```
This allows us to deprecate routes without changing the function body.

Synchronizing the search index with our database is accomplished using [background tasks](https://fastapi.tiangolo.com/tutorial/background-tasks/). In endpoints that create, update, or delete garden data, if the updates to our database succeed, a background task is scheduled to update the search index. This should be transparent to clients.

Synchronizing with the search index can be toggled on and off using a new config variable called `SYNC_SEARCH_INDEX`. It is set to False in the test suite so we don't accidentally send test data to the search index.

## Testing

I have not found a good way to test the synchronization with the search index. My first thought was to patch the functions that update the search index and in the tests for garden routes do something like:
```
mock_update_search_index = mocker.patch(...)
# Run the rest of the test....
mock_update_search_index.assert_called_once()
```
But, because background tasks happen after the endpoint function returns this assertion is flaky.
