### PR TITLE
get multiple entrypoints 

### DIFF
--- a/garden-backend-service/src/api/routes/entrypoints.py
+++ b/garden-backend-service/src/api/routes/entrypoints.py
@@ -73,7 +73,7 @@ async def get_entrypoints(
     if authors:
         stmt = stmt.where(Entrypoint.authors.overlap(array(authors)))
     if owner:
-        stmt = stmt.where(Entrypoint.owner.identity_id == owner)
+        stmt = stmt.join(Entrypoint.owner).where(User.identity_id == owner)
     if draft is not None:
         stmt = stmt.where(Entrypoint.doi_is_draft == draft)
     if year:

--- a/garden-backend-service/src/api/routes/entrypoints.py
+++ b/garden-backend-service/src/api/routes/entrypoints.py
@@ -56,24 +56,24 @@ async def get_entrypoint_by_doi(
 async def get_entrypoints(
     db: AsyncSession = Depends(get_db_session),
     *,
-    dois: list[str] | None = Query(None),
+    doi: list[str] | None = Query(None),
     tags: list[str] | None = Query(None),
     authors: list[str] | None = Query(None),
-    owner: UUID | None = Query(None),
+    owner_uuid: UUID | None = Query(None),
     draft: bool | None = Query(None),
     year: str | None = Query(None),
     limit: int = Query(50),
 ) -> list[EntrypointMetadataResponse]:
     """Fetch multiple entrypoints according to query parameters."""
     stmt = select(Entrypoint)
-    if dois:
-        stmt = stmt.where(Entrypoint.doi.in_(dois))
+    if doi:
+        stmt = stmt.where(Entrypoint.doi.in_(doi))
     if tags:
         stmt = stmt.where(Entrypoint.tags.overlap(array(tags)))
     if authors:
         stmt = stmt.where(Entrypoint.authors.overlap(array(authors)))
-    if owner:
-        stmt = stmt.join(Entrypoint.owner).where(User.identity_id == owner)
+    if owner_uuid:
+        stmt = stmt.join(Entrypoint.owner).where(User.identity_id == owner_uuid)
     if draft is not None:
         stmt = stmt.where(Entrypoint.doi_is_draft == draft)
     if year:

--- a/garden-backend-service/src/api/routes/entrypoints.py
+++ b/garden-backend-service/src/api/routes/entrypoints.py
@@ -73,7 +73,7 @@ async def get_entrypoints(
     if authors:
         stmt = stmt.where(Entrypoint.authors.overlap(array(authors)))
     if owner:
-        stmt = stmt.where(Entrypoint.owner.id == owner)
+        stmt = stmt.where(Entrypoint.owner.identity_id == owner)
     if draft is not None:
         stmt = stmt.where(Entrypoint.doi_is_draft == draft)
     if year:

--- a/garden-backend-service/src/api/routes/entrypoints.py
+++ b/garden-backend-service/src/api/routes/entrypoints.py
@@ -1,6 +1,9 @@
 from logging import getLogger
+from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.dependencies.auth import authed_user
@@ -47,6 +50,37 @@ async def get_entrypoint_by_doi(
             detail=f"Entrypoint not found with DOI {doi}",
         )
     return entrypoint
+
+
+@router.get("", status_code=status.HTTP_200_OK)
+async def get_entrypoints(
+    db: AsyncSession = Depends(get_db_session),
+    *,
+    dois: list[str] | None = Query(None),
+    tags: list[str] | None = Query(None),
+    authors: list[str] | None = Query(None),
+    owner: UUID | None = Query(None),
+    draft: bool | None = Query(None),
+    year: str | None = Query(None),
+    limit: int = Query(50),
+) -> list[EntrypointMetadataResponse]:
+    """Fetch multiple entrypoints according to query parameters."""
+    stmt = select(Entrypoint)
+    if dois:
+        stmt = stmt.where(Entrypoint.doi.in_(dois))
+    if tags:
+        stmt = stmt.where(Entrypoint.tags.overlap(array(tags)))
+    if authors:
+        stmt = stmt.where(Entrypoint.authors.overlap(array(authors)))
+    if owner:
+        stmt = stmt.where(Entrypoint.owner.id == owner)
+    if draft is not None:
+        stmt = stmt.where(Entrypoint.doi_is_draft == draft)
+    if year:
+        stmt = stmt.where(Entrypoint.year == year)
+
+    result = await db.scalars(stmt.limit(limit))
+    return result.all()
 
 
 @router.delete("/{doi:path}", status_code=status.HTTP_200_OK)

--- a/garden-backend-service/src/api/routes/entrypoints.py
+++ b/garden-backend-service/src/api/routes/entrypoints.py
@@ -62,7 +62,7 @@ async def get_entrypoints(
     owner_uuid: UUID | None = Query(None),
     draft: bool | None = Query(None),
     year: str | None = Query(None),
-    limit: int = Query(50),
+    limit: int = Query(50, le=100),
 ) -> list[EntrypointMetadataResponse]:
     """Fetch multiple entrypoints according to query parameters."""
     stmt = select(Entrypoint)

--- a/garden-backend-service/src/api/schemas/entrypoint.py
+++ b/garden-backend-service/src/api/schemas/entrypoint.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import AliasPath, Field
 
 from .base import BaseSchema, UniqueList, Url
 
@@ -64,5 +64,5 @@ class EntrypointCreateRequest(EntrypointMetadata):
 
 
 class EntrypointMetadataResponse(EntrypointMetadata):
-    owner_identity_id: UUID
+    owner_identity_id: UUID = Field(alias=AliasPath("owner", "identity_id"))
     id: int

--- a/garden-backend-service/src/api/schemas/entrypoint.py
+++ b/garden-backend-service/src/api/schemas/entrypoint.py
@@ -64,4 +64,5 @@ class EntrypointCreateRequest(EntrypointMetadata):
 
 
 class EntrypointMetadataResponse(EntrypointMetadata):
+    owner_identity_id: UUID
     id: int

--- a/garden-backend-service/tests/api/routes/test_entrypoints.py
+++ b/garden-backend-service/tests/api/routes/test_entrypoints.py
@@ -156,7 +156,7 @@ async def test_get_entrypoints_with_dois(
     assert response.status_code == 200
 
     doi = mock_entrypoint_create_request_json["doi"]
-    response = await client.get(f"/entrypoints?dois={doi}")
+    response = await client.get(f"/entrypoints?doi={doi}")
     assert response.status_code == 200
     response_data = response.json()
     assert len(response_data) == 1
@@ -240,7 +240,7 @@ async def test_get_entrypoints_with_owner(
     response = await client.post("/entrypoints", json=entrypoint_data_with_owner)
     assert response.status_code == 200
 
-    response = await client.get(f"/entrypoints?owner={owner_id}")
+    response = await client.get(f"/entrypoints?owner_uuid={owner_id}")
     assert response.status_code == 200
     response_data = response.json()
     assert len(response_data) == 1

--- a/garden-backend-service/tests/api/routes/test_entrypoints.py
+++ b/garden-backend-service/tests/api/routes/test_entrypoints.py
@@ -1,6 +1,8 @@
 import copy
 
 import pytest
+from src.api.dependencies.auth import authenticated
+from src.main import app
 
 
 @pytest.mark.asyncio
@@ -137,3 +139,163 @@ async def test_update_entrypoint(
     assert response_data["doi"] == updated_data["doi"]
     assert response_data["title"] == updated_data["title"]
     assert response_data["datasets"][0]["title"] == "Updated Dataset Title"
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_entrypoints_with_dois(
+    client,
+    mock_db_session,
+    mock_entrypoint_create_request_json,
+    override_authenticated_dependency,
+):
+    # Add an entrypoint
+    response = await client.post(
+        "/entrypoints", json=mock_entrypoint_create_request_json
+    )
+    assert response.status_code == 200
+
+    doi = mock_entrypoint_create_request_json["doi"]
+    response = await client.get(f"/entrypoints?dois={doi}")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 1
+    assert response_data[0]["doi"] == doi
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_entrypoints_with_tags(
+    client,
+    mock_db_session,
+    mock_entrypoint_create_request_json,
+    override_authenticated_dependency,
+):
+    # Add an entrypoint with specific tags
+    tags = ["tag1", "tag2"]
+    entrypoint_data_with_tags = copy.deepcopy(mock_entrypoint_create_request_json)
+    entrypoint_data_with_tags["tags"] = tags
+    response = await client.post("/entrypoints", json=entrypoint_data_with_tags)
+    assert response.status_code == 200
+
+    response = await client.get("/entrypoints?tags=tag1")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 1
+    assert "tag1" in response_data[0]["tags"]
+
+    response = await client.get("/entrypoints?tags=tag3")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_entrypoints_with_authors(
+    client,
+    mock_db_session,
+    mock_entrypoint_create_request_json,
+    override_authenticated_dependency,
+):
+    # Add an entrypoint with specific authors
+    authors = ["author1", "author2"]
+    entrypoint_data_with_authors = copy.deepcopy(mock_entrypoint_create_request_json)
+    entrypoint_data_with_authors["authors"] = authors
+    response = await client.post("/entrypoints", json=entrypoint_data_with_authors)
+    assert response.status_code == 200
+
+    response = await client.get("/entrypoints?authors=author1")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 1
+    assert "author1" in response_data[0]["authors"]
+
+    response = await client.get("/entrypoints?authors=author3")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_entrypoints_with_owner(
+    client,
+    mock_db_session,
+    mock_entrypoint_create_request_json,
+    mock_auth_state,
+    mock_auth_state_other_user,
+):
+    # ensure both users in DB
+    app.dependency_overrides[authenticated] = lambda: mock_auth_state_other_user
+    _ = await client.get("/greet")
+    app.dependency_overrides[authenticated] = lambda: mock_auth_state
+    _ = await client.get("/greet")
+
+    # Add entrypoint with other user's uuid
+    owner_id = str(mock_auth_state_other_user.identity_id)
+    entrypoint_data_with_owner = copy.deepcopy(mock_entrypoint_create_request_json)
+    # ... a gift for the madame
+    entrypoint_data_with_owner["owner_identity_id"] = owner_id
+    response = await client.post("/entrypoints", json=entrypoint_data_with_owner)
+    assert response.status_code == 200
+
+    response = await client.get(f"/entrypoints?owner={owner_id}")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 1
+    assert response_data[0]["owner_identity_id"] == owner_id
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_entrypoints_with_draft(
+    client,
+    mock_db_session,
+    mock_entrypoint_create_request_json,
+    override_authenticated_dependency,
+):
+    # Add an entrypoint with draft status
+    entrypoint_data_draft = copy.deepcopy(mock_entrypoint_create_request_json)
+    entrypoint_data_draft["doi_is_draft"] = True
+    response = await client.post("/entrypoints", json=entrypoint_data_draft)
+    assert response.status_code == 200
+
+    response = await client.get("/entrypoints?draft=true")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 1
+    assert response_data[0]["doi_is_draft"] is True
+
+    response = await client.get("/entrypoints?draft=false")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_entrypoints_with_year(
+    client,
+    mock_db_session,
+    mock_entrypoint_create_request_json,
+    override_authenticated_dependency,
+):
+    # Add an entrypoint with a specific year
+    year = "2023"
+    entrypoint_data_with_year = copy.deepcopy(mock_entrypoint_create_request_json)
+    entrypoint_data_with_year["year"] = year
+    response = await client.post("/entrypoints", json=entrypoint_data_with_year)
+    assert response.status_code == 200
+
+    response = await client.get(f"/entrypoints?year={year}")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 1
+    assert response_data[0]["year"] == year
+
+    response = await client.get("/entrypoints?year=2024")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 0

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -117,6 +117,18 @@ def mock_auth_state():
 
 
 @pytest.fixture
+def mock_auth_state_other_user():
+    # this one's a joke about The Other
+    mock_auth = MagicMock(spec=AuthenticationState)
+    mock_auth.username = "Madame.deBeauvoir@ens-paris.fr"
+    mock_auth.identity_id = UUID("10101010-1010-1010-1010-101020101010")
+    mock_auth.token = "tokentokentoken"
+    mock_auth.email = "simone.debeauvoir@ens-paris.fr"
+    mock_auth.name = "Mme. de Beauvoir"
+    return mock_auth
+
+
+@pytest.fixture
 def mock_missing_token():
     def missing_auth_token_effect(authorization=Depends(HTTPBearer(auto_error=False))):
         raise HTTPException(status_code=403, detail="Authorization header missing")


### PR DESCRIPTION
half of #111 

## Overview

now you can GET /entrypoints with query parameters to filter a result set, instead of only being able to fetch one at a time by doi. 

## Discussion

Slightly opinionated interpretation of list query parameters as OR filters rather than AND. This was because (since no entrypoint has more than one DOI) specifying multiple dois like `dois=doi1&dois=doi2&dois=doi3` clearly should mean "entrypoints with doi1 OR doi2 OR doi3". Then I wanted the query parameters to be consistent, so if you specify `tags=tutorial&tags=chemistry`, this grabs entrypoints with _either_ of those tags, not entrypoints with both. 

However, combined query parameters behave like AND -- so `dois=doi1&dois=doi2&dois=doi3&tags=tutorial&tags=chemistry` returns entrypoints which have "any of these 3 dois AND either of these two tags" 

## Testing

unit tests and some manual sanity checks 