### PR TITLE
GET routes for multiple gardens

### DIFF
--- a/garden-backend-service/poetry.lock
+++ b/garden-backend-service/poetry.lock
@@ -376,7 +376,7 @@ files = [
     {file = "charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"},
     {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"},
     {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600nnnd1fa85524c10287f6004fbab87672bf3e1e"},
     {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"},
     {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"},
     {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"},
@@ -1920,6 +1920,20 @@ pytest = ">=6.2.5"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-random-order"
+version = "1.1.1"
+description = "Randomise the order in which pytest tests are run with some control over the randomness"
+optional = false
+python-versions = ">=3.5.0"
+files = [
+    {file = "pytest-random-order-1.1.1.tar.gz", hash = "sha256:4472d7d34f1f1c5f3a359c4ffc5c13ed065232f31eca19c8844c1ab406e79080"},
+    {file = "pytest_random_order-1.1.1-py3-none-any.whl", hash = "sha256:882727a8b597ecd06ede28654ffeb8a6d511a1e4abe1054cca7982f2e42008cd"},
+]
+
+[package.dependencies]
+pytest = ">=3.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2867,3 +2881,4 @@ files = [
 lock-version = "2.0"
 python-versions = "^3.10"
 content-hash = "4b79146133f94a0e49a983f3dd6840e3c4004c8e731811bbc315019b000ea4a7"
+

--- a/garden-backend-service/poetry.lock
+++ b/garden-backend-service/poetry.lock
@@ -376,7 +376,7 @@ files = [
     {file = "charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"},
     {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"},
     {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"},
-    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600nnnd1fa85524c10287f6004fbab87672bf3e1e"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"},
     {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"},
     {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"},
     {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"},
@@ -2880,5 +2880,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4b79146133f94a0e49a983f3dd6840e3c4004c8e731811bbc315019b000ea4a7"
-
+content-hash = "e6e03368373652926242a5c266c72d9e4a10b1128069df8874b1fe366741d9c5"

--- a/garden-backend-service/pyproject.toml
+++ b/garden-backend-service/pyproject.toml
@@ -47,6 +47,7 @@ aiosqlite = "^0.20.0"
 ipython = "^8.25.0"
 testcontainers = "^4.5.1"
 flake8-pytest-style = "^2.0.0"
+pytest-random-order = "^1.1.1"
 
 
 [build-system]
@@ -55,3 +56,4 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 markers = ["integration"]
+addopts = "--random-order"

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -66,7 +66,7 @@ async def search_gardens(
         stmt = stmt.where(Garden.contributors.overlap(array(contributors)))
 
     if tags is not None:
-        stmt = stmt.where(Garden.tags.overlap(array(contributors)))
+        stmt = stmt.where(Garden.tags.overlap(array(tags)))
 
     if year is not None:
         stmt = stmt.where(Garden.year == year)

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -42,6 +42,7 @@ async def add_garden(
 @router.get("", response_model=list[GardenMetadataResponse])
 async def search_gardens(
     doi: Annotated[list[str] | None, Query()] = None,
+    doi_is_draft: Annotated[bool | None, Query()] = None,
     owner_uuid: Annotated[UUID | None, Query()] = None,
     authors: Annotated[list[str] | None, Query()] = None,
     contributors: Annotated[list[str] | None, Query()] = None,
@@ -56,8 +57,11 @@ async def search_gardens(
     if doi is not None:
         stmt = stmt.where(Garden.doi.in_(doi))
 
+    if doi_is_draft is not None:
+        stmt = stmt.where(Garden.doi_is_draft == doi_is_draft)
+
     if owner_uuid is not None:
-        stmt = stmt.join(Garden.user).where(User.identity_id.in_(owner_uuid))
+        stmt = stmt.join(Garden.user).where(User.identity_id == owner_uuid)
 
     if authors is not None:
         stmt = stmt.where(Garden.authors.overlap(array(authors)))

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -48,7 +48,7 @@ async def search_gardens(
     contributors: Annotated[list[str] | None, Query()] = None,
     tags: Annotated[list[str] | None, Query()] = None,
     year: Annotated[str | None, Query()] = None,
-    limit: Annotated[int | None, Query(max_value=100)] = 50,
+    limit: Annotated[int | None, Query(le=100)] = 50,
     db: AsyncSession = Depends(get_db_session),
 ):
     """Fetch multiple gardens according to query parameters"""

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -42,7 +42,7 @@ async def add_garden(
 @router.get("", response_model=list[GardenMetadataResponse])
 async def search_gardens(
     doi: Annotated[list[str] | None, Query()] = None,
-    doi_is_draft: Annotated[bool | None, Query()] = None,
+    draft: Annotated[bool | None, Query()] = None,
     owner_uuid: Annotated[UUID | None, Query()] = None,
     authors: Annotated[list[str] | None, Query()] = None,
     contributors: Annotated[list[str] | None, Query()] = None,
@@ -57,8 +57,8 @@ async def search_gardens(
     if doi is not None:
         stmt = stmt.where(Garden.doi.in_(doi))
 
-    if doi_is_draft is not None:
-        stmt = stmt.where(Garden.doi_is_draft == doi_is_draft)
+    if draft is not None:
+        stmt = stmt.where(Garden.doi_is_draft == draft)
 
     if owner_uuid is not None:
         stmt = stmt.join(Garden.user).where(User.identity_id == owner_uuid)

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -1,5 +1,4 @@
 from logging import getLogger
-from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
@@ -41,17 +40,17 @@ async def add_garden(
 
 @router.get("", response_model=list[GardenMetadataResponse])
 async def search_gardens(
-    uuid: Optional[UUID] = Query(None, description="Filter by user UUID"),
-    authors: Optional[str] = Query(None, description="Comma-separated list of authors"),
-    contributors: Optional[str] = Query(
+    uuid: UUID | None = Query(None, description="Filter by user UUID"),
+    authors: str | None = Query(None, description="Comma-separated list of authors"),
+    contributors: str | None = Query(
         None, description="Comma-separated list of contributors"
     ),
-    tags: Optional[str] = Query(None, description="Comma-separated list of tags"),
-    year: Optional[str] = Query(None, description="Filter by year"),
-    limit: int = Query(
-        20, description="Limit number of gardens returned by the query."
-    ),
-    publisher: Optional[str] = Query(None, description="Filter by publisher"),
+    tags: str | None = Query(None, description="Comma-separated list of tags"),
+    year: str | None = Query(None, description="Filter by year"),
+    publisher: str | None = Query(None, description="Filter by publisher"),
+    language: str | None = Query(None, description="Filter by language"),
+    version: str | None = Query(None, description="Filter by version"),
+    limit: int = Query(20, description="Limit number of gardens returned by the query"),
     db: AsyncSession = Depends(get_db_session),
 ):
     """
@@ -67,6 +66,8 @@ async def search_gardens(
      - publisher
      - tags
      - year
+     - language
+     - version
     """
     stmt = select(Garden)
 
@@ -90,6 +91,12 @@ async def search_gardens(
 
     if year is not None:
         stmt = stmt.where(Garden.year == year)
+
+    if language is not None:
+        stmt = stmt.where(Garden.language == language)
+
+    if publisher is not None:
+        stmt = stmt.where(Garden.publisher == publisher)
 
     if limit > 0:
         stmt = stmt.limit(limit)

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -64,6 +64,9 @@ async def search_gardens(
      - contributors
      - tags
      - year
+
+    Raises:
+        HTTPException: 404 if no gardens are found
     """
     stmt = select(Garden)
 
@@ -91,7 +94,33 @@ async def search_gardens(
     result = await db.execute(stmt)
     gardens = result.scalars().all()
 
-    return gardens
+    if len(gardens) > 0:
+        return gardens
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="No gardens found."
+        )
+
+
+@router.get("", response_model=list[GardenMetadataResponse])
+async def get_users_gardens(
+    authed_user: User = Depends(authed_user),
+    db: AsyncSession = Depends(get_db_session),
+) -> list[GardenMetadataResponse]:
+    """Return all gardens owned by the current authed user.
+
+    Raises:
+       HTTPException: 404 if no gardens are found
+    """
+    stmt = select(Garden).where(Garden.user.identity_id == authed_user.identity_id)
+    gardens = await db.scalars(stmt).all()
+    if len(gardens) > 0:
+        return gardens
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No gardens found for current user.",
+        )
 
 
 @router.get(

--- a/garden-backend-service/src/api/schemas/garden.py
+++ b/garden-backend-service/src/api/schemas/garden.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import AliasPath, Field
 
 from .base import BaseSchema, UniqueList
 from .entrypoint import EntrypointMetadataResponse
@@ -28,5 +28,6 @@ class GardenCreateRequest(GardenMetadata):
 
 
 class GardenMetadataResponse(GardenMetadata):
+    owner_identity_id: UUID = Field(alias=AliasPath("owner", "identity_id"))
     id: int
     entrypoints: list[EntrypointMetadataResponse] = Field(default_factory=list)

--- a/garden-backend-service/tests/api/routes/test_gardens.py
+++ b/garden-backend-service/tests/api/routes/test_gardens.py
@@ -1,6 +1,17 @@
 from copy import deepcopy
 
 import pytest
+from httpx import AsyncClient
+
+
+async def post_garden(client, garden_data):
+    """POST garden data to populate mock DB session.
+
+    NB: this is not a fixture!
+    """
+    response = await client.post("/gardens", json=garden_data)
+    assert response.status_code == 200
+    return response.json()
 
 
 async def post_entrypoints(client, *payloads):
@@ -161,3 +172,203 @@ async def test_put_updated_garden(
     assert response.status_code == 200
     assert len(response.json()["entrypoints"]) == 1
     assert response.json()["title"] == "Updated Title"
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_gardens_no_filters(
+    client: AsyncClient,
+    mock_db_session,
+    override_authenticated_dependency,
+    create_garden_two_entrypoints_json,
+    create_shared_entrypoint_json,
+    create_entrypoint_with_related_metadata_json,
+):
+    await post_entrypoints(
+        client,
+        create_shared_entrypoint_json,
+        create_entrypoint_with_related_metadata_json,
+    )
+    await post_garden(client, create_garden_two_entrypoints_json)
+
+    response = await client.get("/gardens")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["title"] == create_garden_two_entrypoints_json["title"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_gardens_filter_by_user_id(
+    client: AsyncClient,
+    mock_db_session,
+    mock_auth_state,
+    override_authenticated_dependency,
+    create_garden_two_entrypoints_json,
+    create_shared_entrypoint_json,
+    create_entrypoint_with_related_metadata_json,
+):
+    await post_entrypoints(
+        client,
+        create_shared_entrypoint_json,
+        create_entrypoint_with_related_metadata_json,
+    )
+
+    garden1 = deepcopy(create_garden_two_entrypoints_json)
+    garden1["doi"] = "10.1234/doi1"
+
+    garden2 = deepcopy(create_garden_two_entrypoints_json)
+    garden2["doi"] = "10.1234/doi2"
+
+    await post_garden(client, garden1)
+    await post_garden(client, garden2)
+
+    response = await client.get(f"/gardens?uuid={mock_auth_state.identity_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["title"] == garden1["title"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_gardens_filter_by_authors(
+    client: AsyncClient,
+    mock_db_session,
+    override_authenticated_dependency,
+    create_garden_two_entrypoints_json,
+    create_shared_entrypoint_json,
+    create_entrypoint_with_related_metadata_json,
+):
+    await post_entrypoints(
+        client,
+        create_shared_entrypoint_json,
+        create_entrypoint_with_related_metadata_json,
+    )
+
+    garden1 = deepcopy(create_garden_two_entrypoints_json)
+    garden1["authors"] = ["Author 1", "Author 2"]
+    garden1["doi"] = "10.1234/doi1"
+
+    garden2 = deepcopy(create_garden_two_entrypoints_json)
+    garden2["authors"] = ["Author 3"]
+    garden2["doi"] = "10.1234/doi2"
+
+    await post_garden(client, garden1)
+    await post_garden(client, garden2)
+
+    response = await client.get("/gardens?authors=Author 1,Author 2")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["title"] == garden1["title"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_gardens_filter_by_tags(
+    client: AsyncClient,
+    mock_db_session,
+    override_authenticated_dependency,
+    create_garden_two_entrypoints_json,
+    create_shared_entrypoint_json,
+    create_entrypoint_with_related_metadata_json,
+):
+    await post_entrypoints(
+        client,
+        create_shared_entrypoint_json,
+        create_entrypoint_with_related_metadata_json,
+    )
+
+    garden1 = deepcopy(create_garden_two_entrypoints_json)
+    garden1["tags"] = ["Tag 1", "Tag 2"]
+    garden1["doi"] = "10.1234/doi1"
+
+    garden2 = deepcopy(create_garden_two_entrypoints_json)
+    garden2["tags"] = ["Tag 3"]
+    garden2["doi"] = "10.1234/doi2"
+
+    await post_garden(client, garden1)
+    await post_garden(client, garden2)
+
+    response = await client.get("/gardens?tags=Tag 1,Tag 2")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["title"] == garden1["title"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_gardens_filter_by_year(
+    client: AsyncClient,
+    mock_db_session,
+    override_authenticated_dependency,
+    create_garden_two_entrypoints_json,
+    create_shared_entrypoint_json,
+    create_entrypoint_with_related_metadata_json,
+):
+    await post_entrypoints(
+        client,
+        create_shared_entrypoint_json,
+        create_entrypoint_with_related_metadata_json,
+    )
+
+    garden1 = deepcopy(create_garden_two_entrypoints_json)
+    garden1["year"] = "2023"
+    garden1["doi"] = "10.1234/doi1"
+
+    garden2 = deepcopy(create_garden_two_entrypoints_json)
+    garden2["year"] = "2022"
+    garden2["doi"] = "10.1234/doi2"
+
+    await post_garden(client, garden1)
+    await post_garden(client, garden2)
+
+    response = await client.get("/gardens?year=2023")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["title"] == garden1["title"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_gardens_limit(
+    client: AsyncClient,
+    mock_db_session,
+    override_authenticated_dependency,
+    create_garden_two_entrypoints_json,
+    create_shared_entrypoint_json,
+    create_entrypoint_with_related_metadata_json,
+):
+    await post_entrypoints(
+        client,
+        create_shared_entrypoint_json,
+        create_entrypoint_with_related_metadata_json,
+    )
+
+    gardens = [deepcopy(create_garden_two_entrypoints_json) for i in range(5)]
+    for i, garden in enumerate(gardens):
+        garden["title"] = f"Garden {i}"
+        garden["doi"] = f"10.1234/doi{i}"
+        await post_garden(client, garden)
+
+    response = await client.get("/gardens?limit=2")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_gardens_no_results(
+    client: AsyncClient,
+    mock_db_session,
+    override_authenticated_dependency,
+):
+    response = await client.get("/gardens?user_id=9999")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 0

--- a/garden-backend-service/tests/api/routes/test_gardens.py
+++ b/garden-backend-service/tests/api/routes/test_gardens.py
@@ -181,7 +181,15 @@ async def test_search_gardens_by_doi(
     mock_garden_create_request_no_entrypoints_json,
     override_authenticated_dependency,
 ):
+    # Post the garden we are looking for
     await post_garden(client, mock_garden_create_request_no_entrypoints_json)
+
+    # Post another garden
+    new_garden = deepcopy(mock_garden_create_request_no_entrypoints_json)
+    new_garden["doi"] = "new/doi"
+    await post_garden(client, new_garden)
+
+    # Search for the first garden
     response = await client.get(
         "/gardens",
         params={"doi": [mock_garden_create_request_no_entrypoints_json["doi"]]},
@@ -191,6 +199,41 @@ async def test_search_gardens_by_doi(
     assert len(response_data) == 1
     assert (
         response_data[0]["doi"] == mock_garden_create_request_no_entrypoints_json["doi"]
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_gardens_by_doi_is_draft(
+    client,
+    mock_db_session,
+    mock_garden_create_request_no_entrypoints_json,
+    override_authenticated_dependency,
+):
+    # Post the garden we are looking for
+    await post_garden(client, mock_garden_create_request_no_entrypoints_json)
+
+    # Post another garden
+    new_garden = deepcopy(mock_garden_create_request_no_entrypoints_json)
+    new_garden["doi"] = "new/doi"
+    new_garden["doi_is_draft"] = False
+    await post_garden(client, new_garden)
+
+    # Search for the first garden
+    response = await client.get(
+        "/gardens",
+        params={
+            "doi_is_draft": mock_garden_create_request_no_entrypoints_json[
+                "doi_is_draft"
+            ]
+        },
+    )
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 1
+    assert (
+        response_data[0]["doi_is_draft"]
+        == mock_garden_create_request_no_entrypoints_json["doi_is_draft"]
     )
 
 
@@ -206,7 +249,7 @@ async def test_search_gardens_by_owner_uuid(
     await post_garden(client, mock_garden_create_request_no_entrypoints_json)
     response = await client.get(
         "/gardens",
-        params={"uuid": mock_auth_state.identity_id},
+        params={"owner_uuid": mock_auth_state.identity_id},
     )
     assert response.status_code == 200
     response_data = response.json()
@@ -222,7 +265,16 @@ async def test_search_gardens_by_authors(
     mock_garden_create_request_no_entrypoints_json,
     override_authenticated_dependency,
 ):
+    # Post the garden we are looking for
     await post_garden(client, mock_garden_create_request_no_entrypoints_json)
+
+    # Post another garden
+    new_garden = deepcopy(mock_garden_create_request_no_entrypoints_json)
+    new_garden["doi"] = "new/doi"
+    new_garden["authors"] = ["new authors"]
+    await post_garden(client, new_garden)
+
+    # Search for the first garden
     response = await client.get(
         "/gardens",
         params={"authors": mock_garden_create_request_no_entrypoints_json["authors"]},
@@ -243,7 +295,16 @@ async def test_search_gardens_by_contributors(
     mock_garden_create_request_no_entrypoints_json,
     override_authenticated_dependency,
 ):
+    # Post the garden we will search for
     await post_garden(client, mock_garden_create_request_no_entrypoints_json)
+
+    # Post another garden
+    new_garden = deepcopy(mock_garden_create_request_no_entrypoints_json)
+    new_garden["doi"] = "new/doi"
+    new_garden["contributors"] = ["new contributors"]
+    await post_garden(client, new_garden)
+
+    # Search for the first garden
     response = await client.get(
         "/gardens",
         params={
@@ -268,7 +329,16 @@ async def test_search_gardens_by_tags(
     mock_garden_create_request_no_entrypoints_json,
     override_authenticated_dependency,
 ):
+    # Post the garden we will search for
     await post_garden(client, mock_garden_create_request_no_entrypoints_json)
+
+    # Post another garden
+    new_garden = deepcopy(mock_garden_create_request_no_entrypoints_json)
+    new_garden["doi"] = "new/doi"
+    new_garden["tags"] = ["new tags"]
+    await post_garden(client, new_garden)
+
+    # Search for the first garden
     response = await client.get(
         "/gardens",
         params={"tags": mock_garden_create_request_no_entrypoints_json["tags"]},
@@ -289,7 +359,16 @@ async def test_search_gardens_by_year(
     mock_garden_create_request_no_entrypoints_json,
     override_authenticated_dependency,
 ):
+    # Post the garden we will search for
     await post_garden(client, mock_garden_create_request_no_entrypoints_json)
+
+    # Post another garden
+    new_garden = deepcopy(mock_garden_create_request_no_entrypoints_json)
+    new_garden["doi"] = "new/doi"
+    new_garden["year"] = "1970"
+    await post_garden(client, new_garden)
+
+    # Search for the first garden
     response = await client.get(
         "/gardens",
         params={"year": mock_garden_create_request_no_entrypoints_json["year"]},

--- a/garden-backend-service/tests/api/routes/test_gardens.py
+++ b/garden-backend-service/tests/api/routes/test_gardens.py
@@ -191,7 +191,7 @@ async def test_search_gardens_no_filters(
     )
     await post_garden(client, create_garden_two_entrypoints_json)
 
-    response = await client.get("/gardens")
+    response = await client.get("/gardens/search")
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 1
@@ -224,7 +224,7 @@ async def test_search_gardens_filter_by_user_id(
     await post_garden(client, garden1)
     await post_garden(client, garden2)
 
-    response = await client.get(f"/gardens?uuid={mock_auth_state.identity_id}")
+    response = await client.get(f"/gardens/search?uuid={mock_auth_state.identity_id}")
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2
@@ -258,7 +258,7 @@ async def test_search_gardens_filter_by_authors(
     await post_garden(client, garden1)
     await post_garden(client, garden2)
 
-    response = await client.get("/gardens?authors=Author 1,Author 2")
+    response = await client.get("/gardens/search?authors=Author 1,Author 2")
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 1
@@ -292,7 +292,7 @@ async def test_search_gardens_filter_by_tags(
     await post_garden(client, garden1)
     await post_garden(client, garden2)
 
-    response = await client.get("/gardens?tags=Tag 1,Tag 2")
+    response = await client.get("/gardens/search?tags=Tag 1,Tag 2")
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 1
@@ -326,7 +326,7 @@ async def test_search_gardens_filter_by_year(
     await post_garden(client, garden1)
     await post_garden(client, garden2)
 
-    response = await client.get("/gardens?year=2023")
+    response = await client.get("/gardens/search?year=2023")
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 1
@@ -355,7 +355,7 @@ async def test_search_gardens_limit(
         garden["doi"] = f"10.1234/doi{i}"
         await post_garden(client, garden)
 
-    response = await client.get("/gardens?limit=2")
+    response = await client.get("/gardens/search?limit=2")
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2
@@ -368,7 +368,7 @@ async def test_search_gardens_no_results(
     mock_db_session,
     override_authenticated_dependency,
 ):
-    response = await client.get("/gardens?user_id=9999")
+    response = await client.get("/gardens/search?user_id=9999")
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 0

--- a/garden-backend-service/tests/api/routes/test_gardens.py
+++ b/garden-backend-service/tests/api/routes/test_gardens.py
@@ -369,7 +369,9 @@ async def test_search_gardens_no_results(
     override_authenticated_dependency,
 ):
     response = await client.get("/gardens?user_id=9999")
-    assert response.status_code == 404
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 0
 
 
 @pytest.mark.asyncio
@@ -404,4 +406,6 @@ async def test_get_users_gardens_no_results(
     override_authenticated_dependency,
 ):
     response = await client.get("/gardens")
-    assert response.status_code == 404
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 0

--- a/garden-backend-service/tests/api/routes/test_gardens.py
+++ b/garden-backend-service/tests/api/routes/test_gardens.py
@@ -203,18 +203,11 @@ async def test_search_gardens_by_doi(
 async def test_search_gardens_by_owner_uuid(
     client,
     mock_db_session,
-    create_garden_two_entrypoints_json,
-    create_shared_entrypoint_json,
-    create_entrypoint_with_related_metadata_json,
+    mock_garden_create_request_no_entrypoints_json,
     override_authenticated_dependency,
     mock_auth_state,
 ):
-    await post_entrypoints(
-        client,
-        create_shared_entrypoint_json,
-        create_entrypoint_with_related_metadata_json,
-    )
-    await post_garden(client, create_garden_two_entrypoints_json)
+    await post_garden(client, mock_garden_create_request_no_entrypoints_json)
     response = await client.get(
         "/gardens",
         params={"uuid": mock_auth_state.identity_id},
@@ -230,25 +223,19 @@ async def test_search_gardens_by_owner_uuid(
 async def test_search_gardens_by_authors(
     client,
     mock_db_session,
-    create_garden_two_entrypoints_json,
-    create_shared_entrypoint_json,
-    create_entrypoint_with_related_metadata_json,
+    mock_garden_create_request_no_entrypoints_json,
     override_authenticated_dependency,
 ):
-    await post_entrypoints(
-        client,
-        create_shared_entrypoint_json,
-        create_entrypoint_with_related_metadata_json,
-    )
-    await post_garden(client, create_garden_two_entrypoints_json)
+    await post_garden(client, mock_garden_create_request_no_entrypoints_json)
     response = await client.get(
-        "/gardens", params={"authors": create_garden_two_entrypoints_json["authors"]}
+        "/gardens",
+        params={"authors": mock_garden_create_request_no_entrypoints_json["authors"]},
     )
     assert response.status_code == 200
     response_data = response.json()
     assert len(response_data) == 1
     assert set(response_data[0]["authors"]) == set(
-        create_garden_two_entrypoints_json["authors"]
+        mock_garden_create_request_no_entrypoints_json["authors"]
     )
 
 
@@ -257,26 +244,23 @@ async def test_search_gardens_by_authors(
 async def test_search_gardens_by_contributors(
     client,
     mock_db_session,
-    create_garden_two_entrypoints_json,
-    create_shared_entrypoint_json,
-    create_entrypoint_with_related_metadata_json,
+    mock_garden_create_request_no_entrypoints_json,
     override_authenticated_dependency,
 ):
-    await post_entrypoints(
-        client,
-        create_shared_entrypoint_json,
-        create_entrypoint_with_related_metadata_json,
-    )
-    await post_garden(client, create_garden_two_entrypoints_json)
+    await post_garden(client, mock_garden_create_request_no_entrypoints_json)
     response = await client.get(
         "/gardens",
-        params={"contributors": create_garden_two_entrypoints_json["contributors"]},
+        params={
+            "contributors": mock_garden_create_request_no_entrypoints_json[
+                "contributors"
+            ]
+        },
     )
     assert response.status_code == 200
     response_data = response.json()
     assert len(response_data) == 1
     assert set(response_data[0]["contributors"]) == set(
-        create_garden_two_entrypoints_json["contributors"]
+        mock_garden_create_request_no_entrypoints_json["contributors"]
     )
 
 
@@ -285,25 +269,19 @@ async def test_search_gardens_by_contributors(
 async def test_search_gardens_by_tags(
     client,
     mock_db_session,
-    create_garden_two_entrypoints_json,
-    create_shared_entrypoint_json,
-    create_entrypoint_with_related_metadata_json,
+    mock_garden_create_request_no_entrypoints_json,
     override_authenticated_dependency,
 ):
-    await post_entrypoints(
-        client,
-        create_shared_entrypoint_json,
-        create_entrypoint_with_related_metadata_json,
-    )
-    await post_garden(client, create_garden_two_entrypoints_json)
+    await post_garden(client, mock_garden_create_request_no_entrypoints_json)
     response = await client.get(
-        "/gardens", params={"tags": create_garden_two_entrypoints_json["tags"]}
+        "/gardens",
+        params={"tags": mock_garden_create_request_no_entrypoints_json["tags"]},
     )
     assert response.status_code == 200
     response_data = response.json()
     assert len(response_data) == 1
     assert set(response_data[0]["tags"]) == set(
-        create_garden_two_entrypoints_json["tags"]
+        mock_garden_create_request_no_entrypoints_json["tags"]
     )
 
 
@@ -312,24 +290,21 @@ async def test_search_gardens_by_tags(
 async def test_search_gardens_by_year(
     client,
     mock_db_session,
-    create_garden_two_entrypoints_json,
-    create_shared_entrypoint_json,
-    create_entrypoint_with_related_metadata_json,
+    mock_garden_create_request_no_entrypoints_json,
     override_authenticated_dependency,
 ):
-    await post_entrypoints(
-        client,
-        create_shared_entrypoint_json,
-        create_entrypoint_with_related_metadata_json,
-    )
-    await post_garden(client, create_garden_two_entrypoints_json)
+    await post_garden(client, mock_garden_create_request_no_entrypoints_json)
     response = await client.get(
-        "/gardens", params={"year": create_garden_two_entrypoints_json["year"]}
+        "/gardens",
+        params={"year": mock_garden_create_request_no_entrypoints_json["year"]},
     )
     assert response.status_code == 200
     response_data = response.json()
     assert len(response_data) == 1
-    assert response_data[0]["year"] == create_garden_two_entrypoints_json["year"]
+    assert (
+        response_data[0]["year"]
+        == mock_garden_create_request_no_entrypoints_json["year"]
+    )
 
 
 @pytest.mark.asyncio
@@ -337,18 +312,52 @@ async def test_search_gardens_by_year(
 async def test_search_gardens_with_limit(
     client,
     mock_db_session,
-    create_garden_two_entrypoints_json,
-    create_shared_entrypoint_json,
-    create_entrypoint_with_related_metadata_json,
+    mock_garden_create_request_no_entrypoints_json,
     override_authenticated_dependency,
 ):
-    await post_entrypoints(
-        client,
-        create_shared_entrypoint_json,
-        create_entrypoint_with_related_metadata_json,
-    )
-    await post_garden(client, create_garden_two_entrypoints_json)
-    response = await client.get("/gardens", params={"limit": 1})
+    for i in range(10):
+        mock_garden_create_request_no_entrypoints_json["doi"] = f"fake/doi-{i}"
+        await post_garden(client, mock_garden_create_request_no_entrypoints_json)
+    response = await client.get("/gardens", params={"limit": 5})
     assert response.status_code == 200
     response_data = response.json()
-    assert len(response_data) == 1
+    assert len(response_data) == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_multiple_gardens_by_doi(
+    client,
+    mock_db_session,
+    mock_garden_create_request_no_entrypoints_json,
+    override_authenticated_dependency,
+):
+    doi_list = []
+    for i in range(5):
+        mock_garden_create_request_no_entrypoints_json["doi"] = f"fake/doi-{i}"
+        doi_list.append(mock_garden_create_request_no_entrypoints_json["doi"])
+        await post_garden(client, mock_garden_create_request_no_entrypoints_json)
+    response = await client.get("/gardens", params={"doi": doi_list})
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 5
+    assert set([garden["doi"] for garden in response_data]) == set(doi_list)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_multiple_gardens_by_year(
+    client,
+    mock_db_session,
+    mock_garden_create_request_no_entrypoints_json,
+    override_authenticated_dependency,
+):
+    mock_garden_create_request_no_entrypoints_json["year"] = "2023"
+    for i in range(5):
+        mock_garden_create_request_no_entrypoints_json["doi"] = f"fake/doi-{i}"
+        await post_garden(client, mock_garden_create_request_no_entrypoints_json)
+    response = await client.get("/gardens", params={"year": "2023"})
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 5
+    assert all(garden["year"] == "2023" for garden in response_data)

--- a/garden-backend-service/tests/api/routes/test_gardens.py
+++ b/garden-backend-service/tests/api/routes/test_gardens.py
@@ -369,6 +369,39 @@ async def test_search_gardens_no_results(
     override_authenticated_dependency,
 ):
     response = await client.get("/gardens?user_id=9999")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_users_gardens(
+    client: AsyncClient,
+    mock_db_session,
+    override_authenticated_dependency,
+    create_garden_two_entrypoints_json,
+    create_shared_entrypoint_json,
+    create_entrypoint_with_related_metadata_json,
+):
+    await post_entrypoints(
+        client,
+        create_shared_entrypoint_json,
+        create_entrypoint_with_related_metadata_json,
+    )
+    await post_garden(client, create_garden_two_entrypoints_json)
+
+    response = await client.get("/gardens")
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 0
+    assert len(data) == 1
+    assert data[0]["title"] == create_garden_two_entrypoints_json["title"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_users_gardens_no_results(
+    client: AsyncClient,
+    mock_db_session,
+    override_authenticated_dependency,
+):
+    response = await client.get("/gardens")
+    assert response.status_code == 404

--- a/garden-backend-service/tests/api/routes/test_gardens.py
+++ b/garden-backend-service/tests/api/routes/test_gardens.py
@@ -206,7 +206,7 @@ async def test_search_gardens_by_doi(
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_search_gardens_by_doi_is_draft(
+async def test_search_gardens_by_draft(
     client,
     mock_db_session,
     mock_garden_create_request_no_entrypoints_json,
@@ -218,16 +218,14 @@ async def test_search_gardens_by_doi_is_draft(
     # Post another garden
     new_garden = deepcopy(mock_garden_create_request_no_entrypoints_json)
     new_garden["doi"] = "new/doi"
-    new_garden["doi_is_draft"] = False
+    new_garden["doi_is_draft"] = "false"
     await post_garden(client, new_garden)
 
     # Search for the first garden
     response = await client.get(
         "/gardens",
         params={
-            "doi_is_draft": mock_garden_create_request_no_entrypoints_json[
-                "doi_is_draft"
-            ]
+            "draft": mock_garden_create_request_no_entrypoints_json["doi_is_draft"]
         },
     )
     assert response.status_code == 200
@@ -257,7 +255,7 @@ async def test_search_gardens_by_owner_uuid(
     other_users_garden["doi"] = "new/doi"
     await post_garden(client, other_users_garden)
 
-    # Add garden by ther user we are looking for
+    # Add garden by the user we are looking for
     app.dependency_overrides[authenticated] = lambda: mock_auth_state
     _ = await client.get("/greet")
     await post_garden(client, mock_garden_create_request_no_entrypoints_json)

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -117,6 +117,18 @@ def mock_auth_state():
 
 
 @pytest.fixture
+def mock_auth_state_other_user():
+    # this one's a joke about The Other
+    mock_auth = MagicMock(spec=AuthenticationState)
+    mock_auth.username = "Madame.deBeauvoir@ens-paris.fr"
+    mock_auth.identity_id = UUID("10101010-1010-1010-1010-101020101010")
+    mock_auth.token = "tokentokentoken"
+    mock_auth.email = "simone.debeauvoir@ens-paris.fr"
+    mock_auth.name = "Mme. de Beauvoir"
+    return mock_auth
+
+
+@pytest.fixture
 def mock_missing_token():
     def missing_auth_token_effect(authorization=Depends(HTTPBearer(auto_error=False))):
         raise HTTPException(status_code=403, detail="Authorization header missing")

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -205,6 +205,16 @@ def mock_entrypoint_create_request_json() -> dict:
         return json.load(f_in)
 
 
+@pytest.fixture
+def mock_garden_create_request_no_entrypoints_json() -> dict:
+    path = (
+        Path(__file__).parent / "fixtures" / "GardenCreateRequest-no-entrypoints.json"
+    )
+    assert path.exists()
+    with open(path, "r") as f_in:
+        return json.load(f_in)
+
+
 @pytest.fixture(autouse=True)
 def mock_is_doi_registered(mocker):
     mock_garden = mocker.patch("src.api.routes.gardens.is_doi_registered")

--- a/garden-backend-service/tests/fixtures/GardenCreateRequest-no-entrypoints.json
+++ b/garden-backend-service/tests/fixtures/GardenCreateRequest-no-entrypoints.json
@@ -1,0 +1,15 @@
+{
+    "title": "Garden with two entrypoints",
+    "authors": ["Owen"],
+    "contributors": ["Owen :)", "Et", "Al"],
+    "doi": "10.23677/garden-no-entrypoints",
+    "description": "",
+    "publisher": "Garden-AI",
+    "year": "2023",
+    "language": "en",
+    "tags": [],
+    "version": "0.0.1",
+    "entrypoint_aliases": {},
+    "entrypoint_ids": [
+    ]
+}

--- a/garden-backend-service/tests/fixtures/GardenCreateRequest-no-entrypoints.json
+++ b/garden-backend-service/tests/fixtures/GardenCreateRequest-no-entrypoints.json
@@ -1,13 +1,14 @@
 {
-    "title": "Garden with two entrypoints",
+    "title": "Garden with no entrypoints",
     "authors": ["Owen"],
     "contributors": ["Owen :)", "Et", "Al"],
     "doi": "10.23677/garden-no-entrypoints",
+    "doi_is_draft": true,
     "description": "",
     "publisher": "Garden-AI",
     "year": "2023",
     "language": "en",
-    "tags": [],
+    "tags": ["python", "machine learning", "garden-ai"],
     "version": "0.0.1",
     "entrypoint_aliases": {},
     "entrypoint_ids": [


### PR DESCRIPTION
Partially resolves #111 

## Overview

This PR adds a new GET route for getting multiple gardens:
- `/gardens` returns gardens according to query parameters

## Discussion

The query parameters behave like @OwenPriceSkelly  described in #118 

## Testing

Added new unit tests to exercise the new routes.
Tested manually with different combinations of query parameters.
