### PR TITLE
Add `Project = "Garden"` to resource tags

### DIFF
--- a/infra/modules/ecr/main.tf
+++ b/infra/modules/ecr/main.tf
@@ -1,4 +1,3 @@
-
 resource "aws_ecrpublic_repository" "ecr_repo" {
   repository_name = "garden-containers-${var.env}"
   tags = {
@@ -11,6 +10,7 @@ resource "aws_ecrpublic_repository" "ecr_repo" {
 resource "aws_iam_policy" "ecr_backend_write" {
   name        = "ECRBackendWriteAccess-${var.env}"
   description = "ECR write access for backend application"
+  tags        = var.tags
 
   policy = jsonencode({
     Version = "2012-10-17",

--- a/infra/modules/ecr/variables.tf
+++ b/infra/modules/ecr/variables.tf
@@ -2,3 +2,10 @@ variable "env" {
   description = "The environment for the deployment. (dev, prod)"
   type        = string
 }
+
+variable "tags" {
+  type = map(string)
+  default = {
+    Project = "Garden"
+  }
+}

--- a/infra/modules/lightsail/main.tf
+++ b/infra/modules/lightsail/main.tf
@@ -21,8 +21,9 @@ resource "aws_lightsail_container_service" "garden_service" {
 }
 
 resource "aws_lightsail_certificate" "api_cert" {
-  name                      = var.lightsail_certificate_name
-  domain_name               = var.lightsail_certificate_domain_name
+  name        = var.lightsail_certificate_name
+  domain_name = var.lightsail_certificate_domain_name
+  tags        = var.tags
 }
 
 # IAM stuff
@@ -30,6 +31,7 @@ resource "aws_lightsail_certificate" "api_cert" {
 # but inject the actual user credentials for the app at deployment time with the gh action
 resource "aws_iam_user" "lightsail_user" {
   name = "garden_lightsail_user_${var.env}"
+  tags = var.tags
 }
 
 data "aws_iam_policy_document" "secrets_policy" {
@@ -45,6 +47,7 @@ resource "aws_iam_policy" "secrets_policy" {
   name        = "secrets_policy_${var.env}"
   description = "A policy that allows IAM user to read a secret"
   policy      = data.aws_iam_policy_document.secrets_policy.json
+  tags        = var.tags
 }
 
 resource "aws_iam_user_policy_attachment" "lightsail_user_secrets_policy_attachment" {
@@ -56,6 +59,7 @@ resource "aws_iam_user_policy_attachment" "lightsail_user_secrets_policy_attachm
 # define "ecr-pusher" role for lightsail user to assume
 resource "aws_iam_role" "assumable_role" {
   name = "ecr-pusher-${var.env}"
+  tags = var.tags
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -91,6 +95,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 resource "aws_iam_policy" "allow_assume_role_policy" {
   name   = "allow_assume_role_policy_${var.env}"
   policy = data.aws_iam_policy_document.assume_role_policy.json
+  tags   = var.tags
 }
 
 resource "aws_iam_user_policy_attachment" "allow_assume_role_attachment" {

--- a/infra/modules/lightsail/variables.tf
+++ b/infra/modules/lightsail/variables.tf
@@ -1,5 +1,5 @@
 variable "env" {
-  type = string
+  type        = string
   description = "Either 'dev' or 'prod'"
 }
 
@@ -20,11 +20,18 @@ variable "s3_access_policy_arn" {
 
 variable "lightsail_certificate_name" {
   description = "The name of the lightsail certificate for the custom domain, e.g. 'api-dev-certificate'."
-  type = string
+  type        = string
 }
 
 variable "lightsail_certificate_domain_name" {
   # note: may need to manually add record in route53 if corresponding lightsail cert doesn't already exist
   description = "The custom domain name for the deployment, e.g. 'api-dev.thegardens.ai'"
-  type = string
+  type        = string
+}
+
+variable "tags" {
+  type = map(string)
+  default = {
+    Project = "Garden"
+  }
 }

--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -11,10 +11,10 @@ resource "aws_s3_bucket_policy" "public_read_policy" {
     Version = "2012-10-17",
     Statement = [
       {
-        Effect = "Allow",
+        Effect    = "Allow",
         Principal = "*",
-        Action = "s3:GetObject",
-        Resource = "${aws_s3_bucket.pipeline_notebooks_bucket.arn}/*"
+        Action    = "s3:GetObject",
+        Resource  = "${aws_s3_bucket.pipeline_notebooks_bucket.arn}/*"
       }
     ]
   })
@@ -24,6 +24,7 @@ resource "aws_s3_bucket_policy" "public_read_policy" {
 resource "aws_iam_policy" "s3_full_access" {
   name        = "s3_full_access-${var.env}"
   description = "Full access to notebook bucket"
+  tags        = var.tags
 
   policy = jsonencode({
     "Version" : "2012-10-17",

--- a/infra/modules/s3/variables.tf
+++ b/infra/modules/s3/variables.tf
@@ -1,6 +1,8 @@
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type = map(string)
+  default = {
+    Project = "Garden"
+  }
 }
 
 variable "env" {

--- a/infra/modules/secrets_manager/main.tf
+++ b/infra/modules/secrets_manager/main.tf
@@ -30,6 +30,7 @@ data "aws_secretsmanager_secret_version" "datacite_repo_id" {
 resource "aws_iam_policy" "allow_globus_api_key_access_policy" {
   name        = "test-policy-${var.env}"
   description = "A test policy"
+  tags        = var.tags
 
   policy = jsonencode({
     "Version" : "2012-10-17",

--- a/infra/modules/secrets_manager/outputs.tf
+++ b/infra/modules/secrets_manager/outputs.tf
@@ -1,10 +1,10 @@
 output "db_username" {
-  value = jsondecode(data.aws_secretsmanager_secret_version.current.secret_string)["DB_USERNAME"]
+  value       = jsondecode(data.aws_secretsmanager_secret_version.current.secret_string)["DB_USERNAME"]
   description = "Database username retrieved from Secrets Manager."
 }
 
 output "db_password" {
-  value = jsondecode(data.aws_secretsmanager_secret_version.current.secret_string)["DB_PASSWORD"]
+  value       = jsondecode(data.aws_secretsmanager_secret_version.current.secret_string)["DB_PASSWORD"]
   description = "Database password retrieved from Secrets Manager."
-  sensitive = true
+  sensitive   = true
 }

--- a/infra/modules/secrets_manager/variables.tf
+++ b/infra/modules/secrets_manager/variables.tf
@@ -10,5 +10,12 @@ variable "env" {
 
 variable "lightsail_iam_user_name" {
   description = "The IAM user name for the lightsail deployment"
-  type = string
+  type        = string
+}
+
+variable "tags" {
+  type = map(string)
+  default = {
+    Project = "Garden"
+  }
 }


### PR DESCRIPTION
Resolves #52 

## Overview

This PR adds  a tag `Project = "Garden"` to all current terraform resources that take a tag argument.

## Testing

`terraform plan` shows resources will be updated in place to add the new tag. No resources need to be replaced.
