### PR TITLE
Configure automatic backups for RDS instances

### DIFF
--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -60,6 +60,10 @@ resource "aws_db_instance" "garden_db" {
     Environment = var.env
     Project     = "Garden"
   }
+
+  # enable automatic backups
+  backup_retention_period = 14
+  backup_window = "00:00-01:00"
 }
 
 

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -63,7 +63,8 @@ resource "aws_db_instance" "garden_db" {
 
   # enable automatic backups
   backup_retention_period = 14
-  backup_window = "00:00-01:00"
+  # time is UTC
+  backup_window = "04:00-05:00"
 }
 
 


### PR DESCRIPTION
Resolves: #152 

## Overview

Adds configuration to our terraform for enabling automatic backups on our RDS instances.

## Discussion

I set the backups to run at between midnight and 1am eastern time. Backups are kept for 14 days.

From the [aws docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ManagingAutomatedBackups.html) and the [terraform aws module docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#backup_target), I think this is all we need to do to get backups working. Someone should double check me since this feels a little too easy.

## Testing

`terraform plan` looks good to me. It wants to replace the ssh bastion with a new instance, it looks like that is due to a new version of Amazon Linux being available. That should be fine, but we may need to add ssh keys to the new instance.
