### PR TITLE
Reject changes to entrypoint_ids on published Gardens

### DIFF
--- a/garden-backend-service/src/api/schemas/garden.py
+++ b/garden-backend-service/src/api/schemas/garden.py
@@ -52,3 +52,4 @@ class GardenPatchRequest(BaseSchema):
     version: str | None = None
     entrypoint_aliases: dict[str, str] = None
     is_archived: bool | None = None
+    entrypoint_ids: UniqueList[str] | None = None

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -260,6 +260,13 @@ def create_shared_entrypoint_json() -> dict:
 
 
 @pytest.fixture
+def create_published_garden_json() -> dict:
+    path = Path(__file__).parent / "fixtures" / "GardenCreateRequest-published.json"
+    with open(path, "r") as f_in:
+        return json.load(f_in)
+
+
+@pytest.fixture
 def create_garden_two_entrypoints_json() -> dict:
     """Request payload to create a garden referencing two other entrypoints by DOI.
     Note: Trying to create the garden before these entrypoints exist in the DB will cause an error.

--- a/garden-backend-service/tests/fixtures/GardenCreateRequest-published.json
+++ b/garden-backend-service/tests/fixtures/GardenCreateRequest-published.json
@@ -1,0 +1,16 @@
+{
+  "title": "Garden that is published",
+  "authors": ["Shane"],
+  "contributors": ["Shane J", "Et", "Al"],
+  "doi": "10.23677/garden-published",
+  "description": "",
+  "publisher": "Garden-AI",
+  "year": "2023",
+  "language": "en",
+  "tags": [],
+  "version": "0.0.1",
+  "entrypoint_aliases": {},
+  "entrypoint_ids": [],
+  "is_archived": false,
+  "doi_is_draft": false
+}


### PR DESCRIPTION

Builds on #149 and #158, which restricted which fields could be edited on entrypoints

## Overview

Adds ability for unpublished gardens to have their entrypoints edited. Rejects changes to entrypoint_ids on published gardens. Adds an accompanying request to ensure changing this field on a published garden raises an error. 

## Discussion

This PR builds on functionality implemented in #149 that ensured that Gardens and Entrypoints could not be edited while in an archived state. 

## Testing

To test this, I submitted PATCH requests to unpublished and published gardens, with different combinations of fields changed. In particular, we should expect that any PATCH requests that include a change to entrypoint_ids fails *if* that garden is in a published state.  Conversely, we should expect that PATCH requests that include a change to entrypoint_ids succeeds when that Garden is in draft state. I also added an additional unit test that verifies this expected behavior. 