### PR TITLE
Auto-deploy Modal helpers

### DIFF
--- a/.github/workflows/deploy-modal.yml
+++ b/.github/workflows/deploy-modal.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - dev
       - prod
-      - will/auto-deploy-modal-fns
   workflow_dispatch:
 
 

--- a/.github/workflows/deploy-modal.yml
+++ b/.github/workflows/deploy-modal.yml
@@ -1,0 +1,53 @@
+name: Deploy Modal function
+
+on:
+  push:
+    branches:
+      - dev
+      - prod
+      - will/auto-deploy-modal-fns
+  workflow_dispatch:
+
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    # Determine the environment suffix to target to based on the branch
+    # note than manually running this from a branch other than dev or prod
+    # will set env=dev, as though running from the real dev branch.
+    - name: Set Environment
+      id: vars
+      run: |
+        if [[ "${{ github.ref }}" == "refs/heads/prod" ]]; then
+          echo "env=prod" >> $GITHUB_OUTPUT
+        else
+          echo "env=dev" >> $GITHUB_OUTPUT
+        fi
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+    
+    - name: Install Modal
+      run: |
+        python -m pip install --upgrade pip
+        pip install modal
+    
+    - name: Deploy Modal app
+      env:
+        MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+        MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        MODAL_ENVIRONMENT: ${{ steps.vars.outputs.env }}
+      run: |
+        modal deploy ./garden-backend-service/src/sandboxed_functions/modal_publishing_helpers.py
+    

--- a/garden-backend-service/src/api/dependencies/sandboxed_functions.py
+++ b/garden-backend-service/src/api/dependencies/sandboxed_functions.py
@@ -13,7 +13,9 @@ class ValidateModalFileProvider:
             self.f = validate_modal_file
         else:
             remote_function = modal.Function.lookup(
-                "garden-publishing-helpers", "remote_validate_modal_file"
+                "garden-publishing-helpers",
+                "remote_validate_modal_file",
+                environment_name=settings.MODAL_ENV,
             )
             self.f = remote_function.remote
 

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -321,7 +321,9 @@ async def _collect_entrypoints(dois: list[str], db: AsyncSession) -> list[Entryp
     return entrypoints
 
 
-async def _collect_modal_functions(ids: list[int], db: AsyncSession) -> list[ModalFunction]:
+async def _collect_modal_functions(
+    ids: list[int], db: AsyncSession
+) -> list[ModalFunction]:
     stmt = select(ModalFunction).where(ModalFunction.id.in_(ids))
     result = await db.execute(stmt)
     modal_functions: list[ModalFunction] = result.scalars().all()
@@ -371,7 +373,9 @@ async def _create_new_garden(
             )
 
     new_garden: Garden = Garden.from_dict(
-        garden_data.model_dump(exclude={"entrypoint_ids", "modal_function_ids", "owner_identity_id"})
+        garden_data.model_dump(
+            exclude={"entrypoint_ids", "modal_function_ids", "owner_identity_id"}
+        )
     )
     new_garden.owner = owner
     new_garden.entrypoints = entrypoints

--- a/garden-backend-service/src/api/routes/modal/invocations.py
+++ b/garden-backend-service/src/api/routes/modal/invocations.py
@@ -37,7 +37,10 @@ async def invoke_modal_fn(
 
     # fetch the function from modal
     function = await modal.functions._Function.lookup(
-        app_name=body.app_name, tag=body.function_name, client=modal_client
+        app_name=body.app_name,
+        tag=body.function_name,
+        client=modal_client,
+        environment_name=settings.MODAL_ENV,
     )
 
     # create the _Invocation object

--- a/garden-backend-service/src/api/routes/modal/modal_functions.py
+++ b/garden-backend-service/src/api/routes/modal/modal_functions.py
@@ -14,6 +14,7 @@ from structlog import get_logger
 logger = get_logger(__name__)
 router = APIRouter(prefix="/modal-functions")
 
+
 @router.get(
     "/{id}",
     status_code=status.HTTP_200_OK,
@@ -27,7 +28,7 @@ async def get_modal_function(
 ):
     if not settings.MODAL_ENABLED:
         raise NotImplementedError("Garden's Modal integration has not been enabled")
-    
+
     modal_function = await ModalFunction.get(db, id=id)
     if modal_function is None:
         raise HTTPException(


### PR DESCRIPTION
Closes #163. 

## Overview

This PR adds a Github action that auto-deploys our Modal helpers that perform sandboxed operations.

## Discussion

Behind the scenes, I also created the "dev" and "prod" modal envs within the Garden workspace. I updated places where we grab Modal functions to point to the right env based on the Settings. I also added Modal tokens to our secrets in AWS Secrets Manager and GitHub secrets.

## Testing

I ran the GH action manually and confirmed that it deployed the Modal functions.


<img width="1290" alt="Screenshot 2024-10-07 at 3 36 55 PM" src="https://github.com/user-attachments/assets/78e79789-3783-41ad-9b44-ab264792f1c8">
