### PR TITLE
Restrict Modal routes to allow-listed users

### DIFF
--- a/garden-backend-service/src/api/dependencies/auth.py
+++ b/garden-backend-service/src/api/dependencies/auth.py
@@ -14,6 +14,14 @@ from src.models.user import User
 log = get_logger(__name__)
 
 
+# MODAL_VIP_LIST = [
+#     "willengler@uchicago.edu",
+#     "owenpriceskelly@uchicago.edu",
+#     "hholbroo@unca.edu",
+
+#     # Add more email addresses as needed
+# ]
+
 def _get_auth_token(
     authorization: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
 ):
@@ -74,6 +82,17 @@ async def authed_user(
         username=auth.username, user_identity_id=auth.identity_id
     ):
         yield user
+
+
+async def modal_vip(
+    user: User = Depends(authed_user),
+    settings: Settings = Depends(get_settings),
+) -> bool:
+    email = user.email.lower()
+    if email in settings.MODAL_VIP_LIST:
+        return True
+    else:
+        raise HTTPException(status_code=403, detail="Modal endpoints are in limited preview")
 
 
 def get_auth_client(

--- a/garden-backend-service/src/api/dependencies/auth.py
+++ b/garden-backend-service/src/api/dependencies/auth.py
@@ -14,14 +14,6 @@ from src.models.user import User
 log = get_logger(__name__)
 
 
-# MODAL_VIP_LIST = [
-#     "willengler@uchicago.edu",
-#     "owenpriceskelly@uchicago.edu",
-#     "hholbroo@unca.edu",
-
-#     # Add more email addresses as needed
-# ]
-
 def _get_auth_token(
     authorization: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
 ):

--- a/garden-backend-service/src/api/dependencies/auth.py
+++ b/garden-backend-service/src/api/dependencies/auth.py
@@ -84,7 +84,9 @@ async def modal_vip(
     if email in settings.MODAL_VIP_LIST:
         return True
     else:
-        raise HTTPException(status_code=403, detail="Modal endpoints are in limited preview")
+        raise HTTPException(
+            status_code=403, detail="Modal endpoints are in limited preview"
+        )
 
 
 def get_auth_client(

--- a/garden-backend-service/src/api/routes/modal/invocations.py
+++ b/garden-backend-service/src/api/routes/modal/invocations.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends
 from modal._utils.grpc_utils import retry_transient_errors
 from modal_proto import api_pb2
 
-from src.api.dependencies.auth import authed_user
+from src.api.dependencies.auth import authed_user, modal_vip
 from src.api.dependencies.modal import get_modal_client
 from src.api.schemas.modal.invocations import (
     ModalInvocationRequest,
@@ -24,6 +24,7 @@ async def invoke_modal_fn(
     user: User = Depends(authed_user),
     settings: Settings = Depends(get_settings),
     modal_client: modal.Client = Depends(get_modal_client),
+    modal_vip: bool = Depends(modal_vip),
 ):
     if not settings.MODAL_ENABLED:
         raise NotImplementedError("Garden's Modal integration has not been enabled")

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
-from src.api.dependencies.auth import authed_user
+from src.api.dependencies.auth import authed_user, modal_vip
 from src.api.dependencies.database import get_db_session
 from src.api.dependencies.sandboxed_functions import (
     DeployModalAppProvider,
@@ -30,6 +30,7 @@ async def add_modal_app(
     settings: Settings = Depends(get_settings),
     validate_modal_file: ValidateModalFileProvider = validate_modal_file_dep,
     deploy_modal_app: DeployModalAppProvider = deploy_modal_app_dep,
+    modal_vip: bool = Depends(modal_vip),
 ):
     if not settings.MODAL_ENABLED:
         raise NotImplementedError("Garden's Modal integration has not been enabled")
@@ -79,6 +80,7 @@ async def get_modal_app(
     db: AsyncSession = Depends(get_db_session),
     user: User = Depends(authed_user),
     settings: Settings = Depends(get_settings),
+    modal_vip: bool = Depends(modal_vip),
 ):
     if not settings.MODAL_ENABLED:
         raise NotImplementedError("Garden's Modal integration has not been enabled")

--- a/garden-backend-service/src/api/routes/modal/modal_functions.py
+++ b/garden-backend-service/src/api/routes/modal/modal_functions.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
-from src.api.dependencies.auth import authed_user
+from src.api.dependencies.auth import authed_user, modal_vip
 from src.api.dependencies.database import get_db_session
 from src.api.schemas.modal.modal_function import (
     ModalFunctionMetadataResponse,
@@ -24,6 +24,7 @@ async def get_modal_function(
     db: AsyncSession = Depends(get_db_session),
     user: User = Depends(authed_user),
     settings: Settings = Depends(get_settings),
+    modal_vip: bool = Depends(modal_vip),
 ):
     if not settings.MODAL_ENABLED:
         raise NotImplementedError("Garden's Modal integration has not been enabled")

--- a/garden-backend-service/src/config.py
+++ b/garden-backend-service/src/config.py
@@ -67,6 +67,7 @@ class Settings(BaseSettings):
     MODAL_TOKEN_SECRET: str
     MODAL_ENV: str = "dev"
     MODAL_USE_LOCAL: bool = False
+    MODAL_VIP_LIST: list[str]
 
     GARDEN_SEARCH_SQL_DIR: str = "src/api/search/sql.sql"
 

--- a/garden-backend-service/tests/api/routes/modal/test_invocations.py
+++ b/garden-backend-service/tests/api/routes/modal/test_invocations.py
@@ -11,6 +11,7 @@ from src.api.schemas.modal.invocations import (
 
 @pytest.mark.asyncio
 async def test_invoke_modal_fn(
+    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,

--- a/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
@@ -6,6 +6,7 @@ from tests.utils import post_modal_app
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_add_modal_app(
+    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,
@@ -31,6 +32,7 @@ async def test_add_modal_app(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_get_modal_app(
+    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,

--- a/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
@@ -6,6 +6,7 @@ from tests.utils import post_modal_app
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_get_modal_function(
+    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -16,9 +16,9 @@ from testcontainers.postgres import PostgresContainer
 
 from src.api.dependencies.auth import (
     AuthenticationState,
-    modal_vip,
     _get_auth_token,
     authenticated,
+    modal_vip,
 )
 from src.api.dependencies.database import init
 from src.api.dependencies.modal import get_modal_client
@@ -174,9 +174,7 @@ def override_deploy_modal_app_dependency(mock_deploy_modal_app_provider):
 
 @pytest.fixture
 def override_modal_vip():
-    app.dependency_overrides[modal_vip] = (
-        lambda: True
-    )
+    app.dependency_overrides[modal_vip] = lambda: True
     yield
     app.dependency_overrides.clear()
 

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -16,6 +16,7 @@ from testcontainers.postgres import PostgresContainer
 
 from src.api.dependencies.auth import (
     AuthenticationState,
+    modal_vip,
     _get_auth_token,
     authenticated,
 )
@@ -172,6 +173,15 @@ def override_deploy_modal_app_dependency(mock_deploy_modal_app_provider):
 
 
 @pytest.fixture
+def override_modal_vip():
+    app.dependency_overrides[modal_vip] = (
+        lambda: True
+    )
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
 def override_get_modal_client_dependency():
     mock_modal_client = AsyncMock()
     mock_modal_client.stub = MagicMock()
@@ -240,6 +250,7 @@ def mock_settings(db_url):
     mock_settings.MODAL_USE_LOCAL = True
     mock_settings.MODAL_ENABLED = True
     mock_settings.GARDEN_SEARCH_SQL_DIR = "src/api/search/sql.sql"
+    mock_settings.MODAL_VIP_LIST = []
     return mock_settings
 
 


### PR DESCRIPTION
Closes issue #159 

## Overview

The app will fetch a list of VIPs (for now, the dev team) and make sure that only users with email addresses in that list can access Modal routes.

## Discussion


## Testing

I tested this locally by playing with the MODAL_VIP_LIST in my .env. I tried it with my email in it and could access Modal routes. I removed it and I couldn't.