### PR TITLE
Set Modal env vars at app startup time

### DIFF
--- a/garden-backend-service/src/main.py
+++ b/garden-backend-service/src/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -44,6 +45,10 @@ async def lifespan(app: FastAPI):
     settings = get_settings()
     db_session = get_db_session_maker(settings=settings)
     auth_client = get_auth_client()
+
+    # Set Modal env variables
+    os.environ["MODAL_TOKEN_ID"] = settings.MODAL_TOKEN_ID
+    os.environ["MODAL_TOKEN_SECRET"] = settings.MODAL_TOKEN_SECRET
 
     # load text-search sql
     await async_init(db_session, Path(settings.GARDEN_SEARCH_SQL_DIR))


### PR DESCRIPTION
No ticket - this is coming out of iterative debugging to get the end to end flow working

## Overview

Set Modal secrets as env vars at app startup. POST /modal-apps was failing at function lookup time because tokens weren't available.

## Testing

I propose to cowboy test this. (Just get it in dev)
