### PR TITLE
Hot fix: use version of deploy function from correct Modal environment

### DIFF
--- a/garden-backend-service/src/api/dependencies/sandboxed_functions.py
+++ b/garden-backend-service/src/api/dependencies/sandboxed_functions.py
@@ -30,7 +30,9 @@ class DeployModalAppProvider:
             self.f = deploy_modal_app
         else:
             remote_function = modal.Function.lookup(
-                "garden-publishing-helpers", "remote_deploy_modal_app"
+                "garden-publishing-helpers",
+                "remote_deploy_modal_app",
+                environment_name=settings.MODAL_ENV,
             )
             self.f = remote_function.remote
 


### PR DESCRIPTION
🤦 I was not fetching the sandboxed deploy function from the right Modal env