### PR TITLE
fall back to username if authed_user.email is none

### DIFF
--- a/garden-backend-service/src/api/dependencies/auth.py
+++ b/garden-backend-service/src/api/dependencies/auth.py
@@ -80,7 +80,7 @@ async def modal_vip(
     user: User = Depends(authed_user),
     settings: Settings = Depends(get_settings),
 ) -> bool:
-    email = user.email.lower()
+    email = (user.email or user.username).lower()
     if email in settings.MODAL_VIP_LIST:
         return True
     else:


### PR DESCRIPTION
cowboy PR -- [apparently](https://docs.globus.org/api/auth/reference/#token-introspect) the user email we get from globus auth is nullable but the username is not. Users with values for the `email` field won't be impacted, and I confirmed that my `username` is in fact my email 🤷 