### PR TITLE
Tweaks to Modal metadata routes

### DIFF
--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -80,7 +80,6 @@ async def get_modal_app(
     db: AsyncSession = Depends(get_db_session),
     user: User = Depends(authed_user),
     settings: Settings = Depends(get_settings),
-    modal_vip: bool = Depends(modal_vip),
 ):
     if not settings.MODAL_ENABLED:
         raise NotImplementedError("Garden's Modal integration has not been enabled")

--- a/garden-backend-service/src/api/routes/modal/modal_functions.py
+++ b/garden-backend-service/src/api/routes/modal/modal_functions.py
@@ -28,7 +28,6 @@ async def get_modal_function(
     db: AsyncSession = Depends(get_db_session),
     user: User = Depends(authed_user),
     settings: Settings = Depends(get_settings),
-    modal_vip: bool = Depends(modal_vip),
 ):
     if not settings.MODAL_ENABLED:
         raise NotImplementedError("Garden's Modal integration has not been enabled")

--- a/garden-backend-service/src/api/schemas/modal/modal_app.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_app.py
@@ -22,7 +22,7 @@ class ModalAppCreateRequest(ModalAppMetadata):
 
 class ModalAppMetadataResponse(ModalAppMetadata):
     owner_identity_id: UUID = Field(alias=AliasPath("owner", "identity_id"))
-    id: int
+    id: int = Field(..., description="The unique identifier for the modal app")
     modal_functions: list[ModalFunctionMetadataResponse] = Field(default_factory=list)
 
     @computed_field

--- a/garden-backend-service/src/api/schemas/modal/modal_function.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_function.py
@@ -1,3 +1,5 @@
+from pydantic import Field
+
 from ..shared_function_schemas import CommonFunctionMetadata, CommonFunctionPatchRequest
 
 
@@ -10,7 +12,7 @@ class ModalFunctionMetadata(CommonFunctionMetadata):
 
 
 class ModalFunctionMetadataResponse(ModalFunctionMetadata):
-    id: int
+    id: int = Field(..., description="The unique identifier for the modal function")
     modal_app_id: int
 
 


### PR DESCRIPTION
Doing this while I'm fixing up Shane's frontend branch. Two things:

- The `id` field in Modal Apps and Modal Functions wasn't showing up in our auto-gen'd OpenAPI schema. `id` is treated specially apparently. We want that field in there for the frontend to have in its types.
- I removed the Modal VIP gate from GET /modal-apps and GET /modal-functions. This lets us fetch and show Modal Functions in the garden view without worrying about 500s for non-VIPs.