### PR TITLE
Include modal functions in garden search results

### DIFF
--- a/garden-backend-service/src/api/search/sql.sql
+++ b/garden-backend-service/src/api/search/sql.sql
@@ -1,5 +1,7 @@
-CREATE OR REPLACE FUNCTION search_gardens(search_query TEXT)
-RETURNS TABLE (garden_id int, rank real) AS $$
+CREATE OR REPLACE FUNCTION search_gardens(search_query text)
+RETURNS TABLE(garden_id int, rank real)
+AS
+    $$
 DECLARE
     query tsquery := websearch_to_tsquery(search_query);
 BEGIN
@@ -11,19 +13,32 @@ BEGIN
          INNER JOIN entrypoint_documents ed
          ON ge.entrypoint_id = ed.id
          GROUP BY ge.garden_id
+    ), modal_function_ranks AS (
+         SELECT gm.garden_id,
+                COALESCE(SUM(ts_rank(mf.mf_document, query)), 0) AS rank
+         FROM gardens_modal_functions gm
+         INNER JOIN modal_function_documents mf
+         ON gm.modal_function_id = mf.id
+         GROUP BY gm.garden_id
     ), garden_ranks AS (
        SELECT gd.garden_id,
-              COALESCE(ts_rank(gd.garden_document, query), 0) + COALESCE(ep_ranks.rank, 0) AS rank
+              COALESCE(ts_rank(gd.garden_document, query), 0)
+              + COALESCE(ep_ranks.rank, 0)
+              + COALESCE(mf_ranks.rank, 0) AS rank
        FROM garden_documents gd
        LEFT JOIN ep_ranks
        ON ep_ranks.garden_id = gd.garden_id
+       LEFT JOIN modal_function_ranks mf_ranks
+       ON mf_ranks.garden_id = gd.garden_id
     )
     SELECT gr.garden_id, gr.rank
     FROM garden_ranks gr
     WHERE gr.rank > 0
     ORDER BY gr.rank DESC;
 END;
-$$ LANGUAGE plpgsql;
+$$
+language plpgsql
+;
 
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS garden_documents AS
@@ -37,7 +52,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS garden_documents AS
 
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS entrypoint_documents AS
-    SELECT id,
+    SELECT e.id,
     setweight(to_tsvector(array_to_string(e.authors, ' ')), 'A') ||
     setweight(to_tsvector(array_to_string(e.tags, ' ')), 'B') ||
     setweight(to_tsvector(e.title), 'D') ||
@@ -45,27 +60,54 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS entrypoint_documents AS
     FROM entrypoints e;
 
 
+CREATE MATERIALIZED VIEW IF NOT EXISTS modal_function_documents AS
+    SELECT mf.id,
+    setweight(to_tsvector(array_to_string(mf.authors, ' ')), 'A') ||
+    setweight(to_tsvector(array_to_string(mf.tags, ' ')), 'A') ||
+    setweight(to_tsvector(mf.title), 'D') ||
+    setweight(to_tsvector(mf.description), 'D') AS mf_document
+    FROM modal_functions mf;
+
+
 CREATE INDEX IF NOT EXISTS garden_documents_index ON garden_documents USING GIN(garden_document);
 CREATE INDEX IF NOT EXISTS entrypoint_documents_index ON entrypoint_documents USING GIN(ep_document);
+CREATE INDEX IF NOT EXISTS modal_function_documents_index ON modal_function_documents USING GIN(mf_document);
 
 
 CREATE OR REPLACE FUNCTION refresh_garden_documents()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER
+AS $$
 BEGIN
     REFRESH MATERIALIZED VIEW garden_documents;
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$
+LANGUAGE plpgsql
+;
 
 
 CREATE OR REPLACE FUNCTION refresh_entrypoint_documents()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER
+AS $$
 BEGIN
     REFRESH MATERIALIZED VIEW entrypoint_documents;
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$
+LANGUAGE plpgsql
+;
 
+
+CREATE OR REPLACE FUNCTION refresh_modal_function_documents()
+RETURNS TRIGGER
+AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW modal_function_documents;
+    RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql
+;
 
 CREATE OR REPLACE TRIGGER garden_documents_trigger
 AFTER INSERT OR UPDATE OF authors,
@@ -84,3 +126,12 @@ AFTER INSERT OR UPDATE OF authors,
                 title
 ON entrypoints
 EXECUTE FUNCTION refresh_entrypoint_documents();
+
+
+CREATE OR REPLACE TRIGGER modal_function_documents_trigger
+AFTER INSERT OR UPDATE OF authors,
+                tags,
+                description,
+                title
+ON modal_functions
+EXECUTE FUNCTION refresh_modal_function_documents();

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -112,6 +112,7 @@ def mock_db_session(
     with Session(_sync_engine) as db:
         db.execute(text("DROP MATERIALIZED VIEW garden_documents;"))
         db.execute(text("DROP MATERIALIZED VIEW entrypoint_documents;"))
+        db.execute(text("DROP MATERIALIZED VIEW modal_function_documents;"))
         db.commit()
     Base.metadata.drop_all(_sync_engine)
 


### PR DESCRIPTION
Resolves: #189 

## Overview

This PR adds the necessary SQL statements to include modal functions in garden search results the same way entrypoints are considered. This adds a materialized view called `modal_functions_documents` for storing the text search documents for modal functions, as well as an index, and a trigger to update the view. The documents include the title, description, tags, and authors for each modal function. If a modal function matches the search query, its associated garden is included in the results.

## Discussion

Newly created gardens do not show on the search page. The frontend filters gardens where `doi_is_draft` is true. Maybe we want to add a `hidden` or `visibility` attribute to gardens and use that to filter gardens on the frontend separate from the doi status?

## Testing

Manual testing with my local database.
