### PR TITLE
Setup middleware to handle Modal exceptions and improve logging

### DIFF
--- a/garden-backend-service/src/api/dependencies/modal.py
+++ b/garden-backend-service/src/api/dependencies/modal.py
@@ -1,5 +1,6 @@
 import modal
-from fastapi import Depends
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse
 
 from src.config import Settings, get_settings
 
@@ -7,4 +8,29 @@ from src.config import Settings, get_settings
 async def get_modal_client(settings: Settings = Depends(get_settings)) -> modal.Client:
     return await modal.client._Client.from_credentials(
         settings.MODAL_TOKEN_ID, settings.MODAL_TOKEN_SECRET
+    )
+
+
+class ModalException(Exception):
+    def __init__(
+        self,
+        detail: str,
+        status_code=400,
+        suggested_fix: str | None = None,
+    ) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+        self.suggested_fix = suggested_fix
+
+
+def handle_modal_exception(request: Request, error: ModalException):
+    content = {
+        "detail": error.detail,
+        "suggested_fix": error.suggested_fix,
+    }
+
+    return JSONResponse(
+        status_code=error.status_code,
+        content=content,
     )

--- a/garden-backend-service/src/api/dependencies/modal.py
+++ b/garden-backend-service/src/api/dependencies/modal.py
@@ -1,6 +1,5 @@
 import modal
-from fastapi import Depends, Request
-from fastapi.responses import JSONResponse
+from fastapi import Depends
 
 from src.config import Settings, get_settings
 
@@ -8,29 +7,4 @@ from src.config import Settings, get_settings
 async def get_modal_client(settings: Settings = Depends(get_settings)) -> modal.Client:
     return await modal.client._Client.from_credentials(
         settings.MODAL_TOKEN_ID, settings.MODAL_TOKEN_SECRET
-    )
-
-
-class ModalException(Exception):
-    def __init__(
-        self,
-        detail: str,
-        status_code=400,
-        suggested_fix: str | None = None,
-    ) -> None:
-        super().__init__(detail)
-        self.detail = detail
-        self.status_code = status_code
-        self.suggested_fix = suggested_fix
-
-
-def handle_modal_exception(request: Request, error: ModalException):
-    content = {
-        "detail": error.detail,
-        "suggested_fix": error.suggested_fix,
-    }
-
-    return JSONResponse(
-        status_code=error.status_code,
-        content=content,
     )

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -65,7 +65,7 @@ async def add_modal_app(
             settings.MODAL_ENV,
         )
     except Exception as e:
-        # TODO figure out what types of errors get thorws, write better suggested fixes
+        # TODO figure out what types of errors get thorwn due to user error, write better suggested fixes
         raise ModalException(
             detail=f"Failed to deploy App on Modal: {e}",
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -4,7 +4,6 @@ from structlog import get_logger
 
 from src.api.dependencies.auth import authed_user, modal_vip
 from src.api.dependencies.database import get_db_session
-from src.api.dependencies.modal import ModalException
 from src.api.dependencies.sandboxed_functions import (
     DeployModalAppProvider,
     ValidateModalFileProvider,
@@ -14,6 +13,7 @@ from src.api.schemas.modal.modal_app import (
     ModalAppMetadataResponse,
 )
 from src.config import Settings, get_settings
+from src.exceptions.modal import ModalException
 from src.models import ModalApp, User
 
 logger = get_logger(__name__)

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -4,6 +4,7 @@ from structlog import get_logger
 
 from src.api.dependencies.auth import authed_user, modal_vip
 from src.api.dependencies.database import get_db_session
+from src.api.dependencies.modal import ModalException
 from src.api.dependencies.sandboxed_functions import (
     DeployModalAppProvider,
     ValidateModalFileProvider,
@@ -40,24 +41,36 @@ async def add_modal_app(
     metadata = validate_modal_file(modal_app.file_contents)
 
     if metadata["app_name"] != modal_app.app_name:
-        raise ValueError("App name in metadata does not match the provided app name")
+        raise ModalException(
+            detail="App name in the modal file does not match the provided app name",
+            suggested_fix="Make sure Modal App name in the Modal file (e.g. `modal.App('my-app-name')`) matches provided App Name",
+        )
 
     if set(metadata["functions"].keys()) != set(modal_app.modal_function_names):
-        raise ValueError(
-            "Function names in metadata do not match the provided function names"
+        raise ModalException(
+            detail="Function names in the modal file do not match the provided function names",
+            suggested_fix="Make sure function names in the Modal file match the provided function names.",
         )
 
     # If everything looks good, we will go on to deploy the App.
     prefixed_app_name = f"{user.identity_id}-{modal_app.app_name}"
 
     # TODO: set a timeout for this and/or make it async
-    deploy_modal_app(
-        modal_app.file_contents,
-        prefixed_app_name,
-        settings.MODAL_TOKEN_ID,
-        settings.MODAL_TOKEN_SECRET,
-        settings.MODAL_ENV,
-    )
+    try:
+        deploy_modal_app(
+            modal_app.file_contents,
+            prefixed_app_name,
+            settings.MODAL_TOKEN_ID,
+            settings.MODAL_TOKEN_SECRET,
+            settings.MODAL_ENV,
+        )
+    except Exception as e:
+        # TODO figure out what types of errors get thorws, write better suggested fixes
+        raise ModalException(
+            detail=f"Failed to deploy App on Modal: {e}",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            suggested_fix="Make sure provided modal file is valid.",
+        )
 
     model_dict = modal_app.model_dump(
         exclude={"modal_function_names", "owner_identity_id", "id"}, exclude_unset=True

--- a/garden-backend-service/src/exceptions/modal.py
+++ b/garden-backend-service/src/exceptions/modal.py
@@ -1,0 +1,27 @@
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+
+class ModalException(Exception):
+    def __init__(
+        self,
+        detail: str,
+        status_code=400,
+        suggested_fix: str | None = None,
+    ) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+        self.suggested_fix = suggested_fix
+
+
+def handle_modal_exception(request: Request, error: ModalException):
+    content = {
+        "detail": error.detail,
+        "suggested_fix": error.suggested_fix,
+    }
+
+    return JSONResponse(
+        status_code=error.status_code,
+        content=content,
+    )

--- a/garden-backend-service/src/exceptions/utils.py
+++ b/garden-backend-service/src/exceptions/utils.py
@@ -1,0 +1,30 @@
+import re
+import traceback
+
+
+def format_traceback(exc: Exception, func_to_stop_at: str = "run_endpoint_function"):
+    """Filter the stack trace to include only the relevant part from the endpoint call to the error."""
+    tb = traceback.extract_tb(exc.__traceback__)  # Extract the stack frames
+
+    # Find the frame for the most recent endpoint call
+    relevant_frames = []
+
+    for frame in reversed(tb):  # Walk the stack from the bottom (most recent call)
+        filename, lineno, funcname, text = frame
+
+        # stop when we hit the inital call to the endpoint
+        if funcname == func_to_stop_at:
+            break
+
+        relevant_frames.append(frame)
+
+    # If we found relevant frames, remove the noisy stuff
+    if relevant_frames:
+        filtered_tb = traceback.format_list(
+            reversed(relevant_frames)
+        )  # Reverse to maintain original order
+        cleaned_tb = [re.sub(r"(\^+)", "", line).strip() for line in filtered_tb]
+        return "".join(cleaned_tb)
+
+    # Fallback to the full traceback if no endpoint call was found
+    return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))

--- a/garden-backend-service/src/middleware/logging.py
+++ b/garden-backend-service/src/middleware/logging.py
@@ -4,30 +4,30 @@ import traceback
 import uuid
 
 import structlog
-from fastapi import HTTPException, Request, Response
+from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from src.api.dependencies.modal import ModalException, handle_modal_exception
 
 
-def filter_stacktrace(exc: Exception):
+def filter_stacktrace(exc: Exception, func_to_stop_at: str = "run_endpoint_function"):
     """Filter the stack trace to include only the relevant part from the endpoint call to the error."""
     tb = traceback.extract_tb(exc.__traceback__)  # Extract the stack frames
 
-    # Find the frame for the most recent dispatch call
+    # Find the frame for the most recent endpoint call
     relevant_frames = []
 
     for frame in reversed(tb):  # Walk the stack from the bottom (most recent call)
         filename, lineno, funcname, text = frame
 
         # stop when we hit the inital call to the endpoint
-        if funcname == "run_endpoint_function":
+        if funcname == func_to_stop_at:
             break
 
         relevant_frames.append(frame)
 
-    # If we found relevant frames, format them
+    # If we found relevant frames, remove the noisy stuff
     if relevant_frames:
         filtered_tb = traceback.format_list(
             reversed(relevant_frames)
@@ -104,8 +104,6 @@ class ErrorHandlingMiddleware(BaseHTTPMiddleware):
                 suggested_fix=e.suggested_fix,
             )
             return handle_modal_exception(request, e)
-        except HTTPException:
-            raise
         except Exception as e:
             filtered_stacktrace = filter_stacktrace(e)
             logger = structlog.get_logger()

--- a/garden-backend-service/src/middleware/logging.py
+++ b/garden-backend-service/src/middleware/logging.py
@@ -1,10 +1,42 @@
+import re
 import time
+import traceback
 import uuid
 
 import structlog
 from fastapi import HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
+
+from src.api.dependencies.modal import ModalException, handle_modal_exception
+
+
+def filter_stacktrace(exc: Exception):
+    """Filter the stack trace to include only the relevant part from the endpoint call to the error."""
+    tb = traceback.extract_tb(exc.__traceback__)  # Extract the stack frames
+
+    # Find the frame for the most recent dispatch call
+    relevant_frames = []
+
+    for frame in reversed(tb):  # Walk the stack from the bottom (most recent call)
+        filename, lineno, funcname, text = frame
+
+        # stop when we hit the inital call to the endpoint
+        if funcname == "run_endpoint_function":
+            break
+
+        relevant_frames.append(frame)
+
+    # If we found relevant frames, format them
+    if relevant_frames:
+        filtered_tb = traceback.format_list(
+            reversed(relevant_frames)
+        )  # Reverse to maintain original order
+        cleaned_tb = [re.sub(r"(\^+)", "", line).strip() for line in filtered_tb]
+        return "".join(cleaned_tb)
+
+    # Fallback to the full traceback if no endpoint call was found
+    return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
 
 
 class LogRequestIdMiddleware(BaseHTTPMiddleware):
@@ -59,13 +91,27 @@ class ErrorHandlingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         try:
             return await call_next(request)
+        except ModalException as e:
+            logger = structlog.get_logger()
+            filtered_stacktrace = filter_stacktrace(e)
+            logger.error(
+                "Modal Exception",
+                method=request.method,
+                path=request.url.path,
+                status_code=e.status_code,
+                stack_trace=filtered_stacktrace,
+                detail=e.detail,
+                suggested_fix=e.suggested_fix,
+            )
+            return handle_modal_exception(request, e)
         except HTTPException:
             raise
-        except Exception:
+        except Exception as e:
+            filtered_stacktrace = filter_stacktrace(e)
             logger = structlog.get_logger()
             logger.error(
                 "Unhandled exception",
-                exc_info=True,
+                stack_trace=filtered_stacktrace,
                 method=request.method,
                 path=request.url.path,
             )

--- a/garden-backend-service/src/middleware/logging.py
+++ b/garden-backend-service/src/middleware/logging.py
@@ -1,6 +1,4 @@
-import re
 import time
-import traceback
 import uuid
 
 import structlog
@@ -8,35 +6,8 @@ from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from src.api.dependencies.modal import ModalException, handle_modal_exception
-
-
-def filter_stacktrace(exc: Exception, func_to_stop_at: str = "run_endpoint_function"):
-    """Filter the stack trace to include only the relevant part from the endpoint call to the error."""
-    tb = traceback.extract_tb(exc.__traceback__)  # Extract the stack frames
-
-    # Find the frame for the most recent endpoint call
-    relevant_frames = []
-
-    for frame in reversed(tb):  # Walk the stack from the bottom (most recent call)
-        filename, lineno, funcname, text = frame
-
-        # stop when we hit the inital call to the endpoint
-        if funcname == func_to_stop_at:
-            break
-
-        relevant_frames.append(frame)
-
-    # If we found relevant frames, remove the noisy stuff
-    if relevant_frames:
-        filtered_tb = traceback.format_list(
-            reversed(relevant_frames)
-        )  # Reverse to maintain original order
-        cleaned_tb = [re.sub(r"(\^+)", "", line).strip() for line in filtered_tb]
-        return "".join(cleaned_tb)
-
-    # Fallback to the full traceback if no endpoint call was found
-    return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+from src.exceptions.modal import ModalException, handle_modal_exception
+from src.exceptions.utils import format_traceback
 
 
 class LogRequestIdMiddleware(BaseHTTPMiddleware):
@@ -93,7 +64,7 @@ class ErrorHandlingMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
         except ModalException as e:
             logger = structlog.get_logger()
-            filtered_stacktrace = filter_stacktrace(e)
+            filtered_stacktrace = format_traceback(e)
             logger.error(
                 "Modal Exception",
                 method=request.method,
@@ -105,7 +76,7 @@ class ErrorHandlingMiddleware(BaseHTTPMiddleware):
             )
             return handle_modal_exception(request, e)
         except Exception as e:
-            filtered_stacktrace = filter_stacktrace(e)
+            filtered_stacktrace = format_traceback(e)
             logger = structlog.get_logger()
             logger.error(
                 "Unhandled exception",

--- a/garden-backend-service/src/sandboxed_functions/modal_publishing_helpers.py
+++ b/garden-backend-service/src/sandboxed_functions/modal_publishing_helpers.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import modal
 
-from src.api.dependencies.modal import ModalException
+from src.exceptions.modal import ModalException
 
 app = modal.App("garden-publishing-helpers")
 

--- a/garden-backend-service/src/sandboxed_functions/modal_publishing_helpers.py
+++ b/garden-backend-service/src/sandboxed_functions/modal_publishing_helpers.py
@@ -3,6 +3,8 @@ from typing import Any
 
 import modal
 
+from src.api.dependencies.modal import ModalException
+
 app = modal.App("garden-publishing-helpers")
 
 modal_helper_image = modal.Image.debian_slim(python_version="3.11").pip_install(
@@ -30,11 +32,42 @@ def get_app_from_file_contents(file_contents: str):
 
     try:
         user_app = import_app(tmp_file_path)
-    except Exception as e:
-        # TODO: identify failure modes and propagate those back
-        raise e
-
+    except Exception:
+        raise ModalException(
+            detail="Failed to import app from Modal File",
+            suggested_fix="Make sure provided Modal file has a `modal.App` object called `app` in the global scope. e.g `app = modal.App('my-app')`",
+        )
     return user_app
+
+
+def get_function_specs(
+    functions: dict[str, modal.Function],
+    specs: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Return function names mapped to their respective specs.
+
+    Raises `ModalException` when a requested spec is not found,
+    This behavior alerts us if/when Modal changes their `_FunctionSpec` schema
+    """
+    return {
+        name: extract_from_dict(dataclasses.asdict(func.spec), specs)
+        for name, func in functions.items()
+    }
+
+
+def extract_from_dict(d: dict[str, Any], keys: list[str]) -> dict[str, Any]:
+    """Return a new dict with only the keys matching the given list.
+
+    Raises `ModalException` when a given key is not present in `d`
+    """
+    try:
+        return {key: d[key] for key in keys}
+    except Exception:
+        raise ModalException(
+            detail="Failed to parse function hardware spec.",
+            status_code=500,
+            suggested_fix="Please contact the Garden-AI dev team.",
+        )
 
 
 #
@@ -52,29 +85,6 @@ def validate_modal_file(file_contents: str):
     return {"app_name": app_name, "functions": functions}
 
     # TODO: confirm nothing dastardly on the app/functions
-
-
-def get_function_specs(
-    functions: dict[str, modal.Function],
-    specs: list[str],
-) -> dict[str, dict[str, Any]]:
-    """Return function names mapped to their respective specs.
-
-    Raises `KeyError` when a requested spec is not found,
-    This behavior alerts us if/when Modal changes their `_FunctionSpec` schema
-    """
-    return {
-        name: extract_from_dict(dataclasses.asdict(func.spec), specs)
-        for name, func in functions.items()
-    }
-
-
-def extract_from_dict(d: dict[str, Any], keys: list[str]) -> dict[str, Any]:
-    """Return a new dict with only the keys matching the given list.
-
-    Raises `KeyError` when a given key is not present in `d`
-    """
-    return {key: d[key] for key in keys}
 
 
 @app.function(image=modal_helper_image)

--- a/garden-backend-service/tests/sandboxed_functions/test_modal_publishing_helpers.py
+++ b/garden-backend-service/tests/sandboxed_functions/test_modal_publishing_helpers.py
@@ -19,7 +19,7 @@ def hello_with_specs():
 def test_get_function_specs_raises_on_invalid_key():
     """Confirms that we will get errors when Modal changes their `_FunctionSpec` schema"""
     invalid_specs = ["some", "specs", "that" "dont", "exist"]
-    with pytest.raises(KeyError):
+    with pytest.raises(Exception):
         get_function_specs(app.registered_functions, invalid_specs)
 
 


### PR DESCRIPTION
Related: #187 -- does not resolve the ticket completely

## Overview

This PR sets us up for better error reporting to the frontend when there are issues with modal deployment/invocations that users should know about, as well as improving the error logs coming from the fastapi server.

This PR defines a new custom exception type `ModalException` that includes fields for:
- details about the error
- suggested fix for the user if it is something they can fix in their code
- http status code

There is logic added to the exception handling middleware that converts a `ModalException` to a `JSONResponse` before sending the response to the client. The middleware logs important details about the exception as well as a stack trace so we can have a better idea of how to help users when something goes wrong. A big improvement in the logging comes from a helper function to remove excess noise from the stack trace.

Since the modal validation/deployment/invocation routes are still in flux, I figured getting a scaffolding in place so that we can raise a `ModalException` with a suggested fix for the user is a good first step. This PR doesn't include errors messages for everything that could wrong, just gets a system in place so we can write specific error messages as we get stuff ironed out. I added a couple `ModalException`s into the `add_modal_app` route so we can see how this setup works in context, however I expect these errors will change as the `add_modal_app` route gets tweaked.

## Discussion

I am not sure that defining the `ModalException` in the dependencies module makes the most sense, but I haven't thought of a better place. I am open to suggestions.

## Testing

Manual testing
