### PR TITLE
Add terraform and GH actions for deploying sandboxed functions as Lambda

### DIFF
--- a/.github/workflows/deploy-lambdas.yml
+++ b/.github/workflows/deploy-lambdas.yml
@@ -1,0 +1,57 @@
+name: deploy-lambdas
+
+on:
+  push:
+    branches:
+      - prod
+      - dev
+  workflow_dispatch:
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: configure aws credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: arn:aws:iam::557062710055:role/GH_Actions_Garden_Deployer
+        role-session-name: garden-backend-deployer
+        aws-region: us-east-1
+
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.12'
+    # Determine the environment suffix to target to based on the branch
+    - name: Set Environment
+      id: vars
+      run: |
+        if [[ "${{ github.ref }}" == "refs/heads/prod" ]]; then
+          echo "::set-output name=env::prod"
+        else
+          echo "::set-output name=env::dev"
+        fi
+    - name: Upload Sandboxed Operations Function
+      run: |
+         # Install the requirements.
+         docker run --rm -v $(pwd):/var/task public.ecr.aws/sam/build-python3.12 /bin/sh -c "\
+            pip install --upgrade pip && \
+            pip install watchfiles --platform manylinux2014_x86_64 --only-binary=:all: --target ./packages && \
+            pip install modal==0.64.224 --target ./packages"
+         # Put the requirements into the top level of our deployable zip archive.
+         cd packages
+         zip -r ../app.zip *
+         cd ../sandboxed_functions
+         zip -r ../authorizer.zip lambda_function.py
+         # Deploy to Lambda.
+         aws lambda update-function-code --function-name GardenAuthorizer-${{ steps.vars.outputs.env }} --zip-file fileb://../authorizer.zip
+         # Delete temporary packages directory
+         cd ..
+         rm -rf packages

--- a/.github/workflows/deploy-lambdas.yml
+++ b/.github/workflows/deploy-lambdas.yml
@@ -49,9 +49,9 @@ jobs:
          cd packages
          zip -r ../app.zip *
          cd ../sandboxed_functions
-         zip -r ../authorizer.zip lambda_function.py
+         zip -r ../app.zip lambda_function.py
          # Deploy to Lambda.
-         aws lambda update-function-code --function-name GardenAuthorizer-${{ steps.vars.outputs.env }} --zip-file fileb://../authorizer.zip
+         aws lambda update-function-code --function-name GardenSandbox-${{ steps.vars.outputs.env }} --zip-file fileb://../app.zip
          # Delete temporary packages directory
          cd ..
          rm -rf packages

--- a/.github/workflows/deploy-lambdas.yml
+++ b/.github/workflows/deploy-lambdas.yml
@@ -8,7 +8,7 @@ on:
       - will/lambda-deployments
   workflow_dispatch:
 permissions:
-  id-token: write   # This is required for requesting the JWT
+  id-token: write   # This is required for requesting the JWT!
   contents: read    # This is required for actions/checkout
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/deploy-lambdas.yml
+++ b/.github/workflows/deploy-lambdas.yml
@@ -17,10 +17,9 @@ jobs:
 
     steps:
     - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::557062710055:role/GH_Actions_Garden_Deployer
-        role-session-name: garden-backend-deployer
         aws-region: us-east-1
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/deploy-lambdas.yml
+++ b/.github/workflows/deploy-lambdas.yml
@@ -52,6 +52,3 @@ jobs:
          zip -r ../app.zip lambda_function.py
          # Deploy to Lambda.
          aws lambda update-function-code --function-name GardenSandbox-${{ steps.vars.outputs.env }} --zip-file fileb://../app.zip
-         # Delete temporary packages directory
-         cd ..
-         rm -rf packages

--- a/.github/workflows/deploy-lambdas.yml
+++ b/.github/workflows/deploy-lambdas.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - prod
       - dev
+      - will/lambda-deployments
   workflow_dispatch:
 permissions:
   id-token: write   # This is required for requesting the JWT

--- a/garden-backend-service/src/sandboxed_functions/modal_publishing_helpers.py
+++ b/garden-backend-service/src/sandboxed_functions/modal_publishing_helpers.py
@@ -3,7 +3,7 @@ import modal
 app = modal.App("garden-publishing-helpers")
 
 modal_helper_image = modal.Image.debian_slim(python_version="3.11").pip_install(
-    "modal==0.64.126"
+    "modal==0.64.178"
 )
 
 #
@@ -56,9 +56,13 @@ def remote_validate_modal_file(file_contents: str):
 def deploy_modal_app(
     file_contents: str, app_name: str, token_id: str, token_secret: str, env: str
 ):
+    import os
+
     from modal import enable_output
     from modal.cli.run import deploy_app, ensure_env
     from modal.client import Client
+
+    os.environ["MODAL_AUTOMOUNT"] = "False"
 
     with enable_output():
         ensure_env(env)

--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -51,6 +51,14 @@ module "lightsail" {
   lightsail_certificate_domain_name = data.aws_acm_certificate.api_cert.domain
 }
 
+module "lambda" {
+  source = "../modules/lambda"
+
+  env                  = var.env
+  aws_account_id       = var.aws_account_id
+  server_name          = module.lightsail.container_service_name
+}
+
 module "rds" {
   source = "../modules/rds"
 

--- a/infra/modules/lambda/main.tf
+++ b/infra/modules/lambda/main.tf
@@ -1,0 +1,52 @@
+/* Sandboxed Lambda */
+
+resource "aws_lambda_function" "sandboxed_app" {
+  function_name = "GardenSandbox-${var.env}"
+
+  filename = "app.zip"
+  runtime  = "python3.12"
+  handler  = "lambda_function.lambda_handler"
+
+  role    = aws_iam_role.lambda_exec.arn
+  timeout = 10
+}
+
+resource "aws_cloudwatch_log_group" "sandboxed_app" {
+  name = "/aws/lambda/${aws_lambda_function.sandboxed_app.function_name}"
+
+  retention_in_days = 30
+}
+
+/* Connect the sandboxed Lambdas to the FastAPI App */
+
+resource "aws_lambda_permission" "garden_lambda_from_server_permission" {
+  statement_id  = "AllowExecutionFromLightsail"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.sandboxed_app.function_name
+  principal     = "lightsail.amazonaws.com"
+
+  # Allow invocation from the specific Lightsail container service
+  source_arn = "arn:aws:lightsail:us-east-1:${var.aws_account_id}:container-service/${var.server_name}"
+}
+
+/* IAM resources */
+
+resource "aws_iam_role" "lambda_exec" {
+  name = "garden_lambda_${var.env}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}

--- a/infra/modules/lambda/outputs.tf
+++ b/infra/modules/lambda/outputs.tf
@@ -1,0 +1,20 @@
+output "garden_app_invoke_arn" {
+  value = aws_lambda_function.sandboxed_app.invoke_arn
+}
+
+output "garden_app_function_name" {
+  value = aws_lambda_function.sandboxed_app.function_name
+}
+
+output "garden_authorizer_invoke_arn" {
+  value = aws_lambda_function.sandboxed_app.invoke_arn
+}
+
+output "garden_authorizer_function_name" {
+  value = aws_lambda_function.sandboxed_app.function_name
+}
+
+
+output "lambda_exec_role_name" {
+  value = aws_iam_role.lambda_exec.name
+}

--- a/infra/modules/lambda/outputs.tf
+++ b/infra/modules/lambda/outputs.tf
@@ -1,19 +1,10 @@
-output "garden_app_invoke_arn" {
+output "garden_sandbox_fn_invoke_arn" {
   value = aws_lambda_function.sandboxed_app.invoke_arn
 }
 
-output "garden_app_function_name" {
+output "garden_sandbox_fn_function_name" {
   value = aws_lambda_function.sandboxed_app.function_name
 }
-
-output "garden_authorizer_invoke_arn" {
-  value = aws_lambda_function.sandboxed_app.invoke_arn
-}
-
-output "garden_authorizer_function_name" {
-  value = aws_lambda_function.sandboxed_app.function_name
-}
-
 
 output "lambda_exec_role_name" {
   value = aws_iam_role.lambda_exec.name

--- a/infra/modules/lambda/variables.tf
+++ b/infra/modules/lambda/variables.tf
@@ -1,0 +1,14 @@
+variable "env" {
+  description = "The environment for the deployment. (dev, prod)"
+  type        = string
+}
+
+variable "server_name" {
+  description = "The name of the Lightsail container service"
+  type        = string
+}
+
+variable "aws_account_id" {
+  description = "The AWS account ID where the resources will be created."
+  type        = string
+}

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -51,6 +51,15 @@ module "lightsail" {
   lightsail_certificate_domain_name = data.aws_acm_certificate.api_cert.domain
 }
 
+module "lambda" {
+  source = "../modules/lambda"
+
+  env                  = var.env
+  aws_account_id       = var.aws_account_id
+  server_name          = module.lightsail.container_service_name
+}
+
+
 module "rds" {
   source = "../modules/rds"
 

--- a/sandboxed_functions/lambda_function.py
+++ b/sandboxed_functions/lambda_function.py
@@ -1,0 +1,88 @@
+def write_to_tmp_file(file_contents: str):
+    import tempfile
+
+    tmp_file_path = tempfile.mktemp() + ".py"
+    with open(tmp_file_path, "w") as f:
+        f.write(file_contents)
+    return tmp_file_path
+
+
+def get_app_from_file_contents(file_contents: str):
+    from modal.cli.import_refs import import_app
+
+    tmp_file_path = write_to_tmp_file(file_contents)
+
+    try:
+        user_app = import_app(tmp_file_path)
+    except Exception as e:
+        # TODO: identify failure modes and propagate those back
+        raise e
+
+    return user_app
+
+
+# def lambda_handler(event, context):
+#     import modal
+#     print(modal)
+#     return "hello"
+
+
+def validate_modal_file(file_contents: str):
+    user_app = get_app_from_file_contents(file_contents)
+    function_names = [f for f in user_app.registered_functions if "*" not in f]
+    app_name = user_app.name
+    return {"function_names": function_names, "app_name": app_name}
+
+    # TODO: confirm nothing dastardly on the app/functions
+
+
+# @app.function(image=modal_helper_image)
+# def remote_validate_modal_file(file_contents: str):
+#     return validate_modal_file(file_contents)
+
+
+def deploy_modal_app(
+    file_contents: str, app_name: str, token_id: str, token_secret: str, env: str
+):
+    from modal import enable_output
+    from modal.cli.run import deploy_app, ensure_env
+    from modal.client import Client
+    import os
+
+    clean_dir = "/tmp/modal_deploy"
+    os.makedirs(clean_dir, exist_ok=True)
+    original_dir = os.getcwd()
+    os.chdir(clean_dir)
+
+    try:
+        with enable_output():
+            ensure_env(env)
+            app = get_app_from_file_contents(file_contents)
+            client = Client.from_credentials(token_id, token_secret)
+            res = deploy_app(app, name=app_name, client=client, environment_name=env)
+    finally:
+        os.chdir(original_dir)
+
+    return res.app_id
+
+
+def lambda_handler(event, context):
+    fn_name = event["fn_name"]
+    payload = event["payload"]
+    if fn_name == "deploy_modal_app":
+        file_contents = payload["file_contents"]
+        app_name = payload["app_name"]
+        token_id = payload["token_id"]
+        token_secret = payload["token_secret"]
+        env = payload["env"]
+        return deploy_modal_app(file_contents, app_name, token_id, token_secret, env)
+    elif fn_name == "validate_modal_file":
+        file_contents = payload["file_contents"]
+        return validate_modal_file(file_contents)
+
+
+# @app.function(image=modal_helper_image)
+# def remote_deploy_modal_app(
+#     file_contents: str, app_name: str, token_id: str, token_secret: str, env: str
+# ):
+#     return deploy_modal_app(file_contents, app_name, token_id, token_secret, env)

--- a/sandboxed_functions/lambda_function.py
+++ b/sandboxed_functions/lambda_function.py
@@ -21,12 +21,6 @@ def get_app_from_file_contents(file_contents: str):
     return user_app
 
 
-# def lambda_handler(event, context):
-#     import modal
-#     print(modal)
-#     return "hello"
-
-
 def validate_modal_file(file_contents: str):
     user_app = get_app_from_file_contents(file_contents)
     function_names = [f for f in user_app.registered_functions if "*" not in f]
@@ -34,11 +28,6 @@ def validate_modal_file(file_contents: str):
     return {"function_names": function_names, "app_name": app_name}
 
     # TODO: confirm nothing dastardly on the app/functions
-
-
-# @app.function(image=modal_helper_image)
-# def remote_validate_modal_file(file_contents: str):
-#     return validate_modal_file(file_contents)
 
 
 def deploy_modal_app(
@@ -79,10 +68,3 @@ def lambda_handler(event, context):
     elif fn_name == "validate_modal_file":
         file_contents = payload["file_contents"]
         return validate_modal_file(file_contents)
-
-
-# @app.function(image=modal_helper_image)
-# def remote_deploy_modal_app(
-#     file_contents: str, app_name: str, token_id: str, token_secret: str, env: str
-# ):
-#     return deploy_modal_app(file_contents, app_name, token_id, token_secret, env)


### PR DESCRIPTION
First step of #185 

## Overview

This PR adds the Terraform, GitHub Action, and skeleton of the Lambda handler needed to run our sandboxed operations from Lambda instead of Modal. 

## Discussion

To keep it reasonably sized, this PR does not yet actually incorporate the Lambda into the API routes that perform the sandboxed operations. That will come next. This PR is focused on getting the infra and plumbing up. The next one will get it all working. (It will also deduplicate the two `sandboxed_functions` directories!)

## Testing

I tested the lambda function for Modal deployment via a Lambda I made from the dashboard. The critical thing to figure out here was how to correctly bundle up the dependencies. Unlike the old webserver Lambda we deployed, with this one I couldn't just pull binaries from pip for the appropriate platform, so it took a lot of trial and error. Shoutout to the [act](https://github.com/nektos/act) utility which sped up my iteration/testing cycle a lot.