### PR TITLE
Add gate on Modal Publishers group membership

### DIFF
--- a/garden-backend-service/src/api/dependencies/auth.py
+++ b/garden-backend-service/src/api/dependencies/auth.py
@@ -80,19 +80,6 @@ async def authed_user(
         yield user
 
 
-async def modal_vip(
-    user: User = Depends(authed_user),
-    settings: Settings = Depends(get_settings),
-) -> bool:
-    email = (user.email or user.username).lower()
-    if email in settings.MODAL_VIP_LIST:
-        return True
-    else:
-        raise HTTPException(
-            status_code=403, detail="Modal endpoints are in limited preview"
-        )
-
-
 async def under_modal_usage_limit(
     user: User = Depends(authed_user),
     settings: Settings = Depends(get_settings),
@@ -127,3 +114,44 @@ def get_auth_client(
     return globus_sdk.ConfidentialAppAuthClient(
         settings.API_CLIENT_ID, settings.API_CLIENT_SECRET
     )
+
+
+def in_modal_publishers_group(
+    auth: AuthenticationState = Depends(authenticated),
+    auth_client: globus_sdk.ConfidentialAppAuthClient = Depends(get_auth_client),
+    settings: Settings = Depends(get_settings),
+) -> bool:
+    try:
+        dependent_tokens = auth_client.oauth2_get_dependent_tokens(auth.token)
+        access_token = dependent_tokens.by_resource_server["groups.api.globus.org"][
+            "access_token"
+        ]
+    except Exception as e:
+        log.info("Could not recover dependent access token for groups.api.globus.org.")
+        log.exception(e)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Could not determine group membership. Did you consent to share groups.api.globus.org when you logged in?",
+        )
+
+    # Create a Globus Group Client using the access token sent by the user
+    authorizer = globus_sdk.AccessTokenAuthorizer(access_token)
+    groups_client = globus_sdk.GroupsClient(authorizer=authorizer)
+
+    # Collect the list of Globus Groups that the user is a member of
+    try:
+        user_groups = [group["id"] for group in groups_client.get_my_groups()]
+    except Exception as e:
+        log.info("Could not recover group memberships.")
+        log.exception(e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not determine group memberships.",
+        )
+
+    group_id = settings.MODAL_PUBLISHERS_GROUP_ID
+    if group_id not in user_groups:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not a member of the required group to publish Modal functions.",
+        )

--- a/garden-backend-service/src/api/dependencies/auth.py
+++ b/garden-backend-service/src/api/dependencies/auth.py
@@ -155,3 +155,4 @@ def in_modal_publishers_group(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You are not a member of the required group to publish Modal functions.",
         )
+    return True

--- a/garden-backend-service/src/api/routes/modal/invocations.py
+++ b/garden-backend-service/src/api/routes/modal/invocations.py
@@ -6,7 +6,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import modal
 from modal._utils.grpc_utils import retry_transient_errors
-from src.api.dependencies.auth import authed_user, modal_vip, under_modal_usage_limit
+from src.api.dependencies.auth import (
+    authed_user,
+    under_modal_usage_limit,
+)
 from src.api.dependencies.database import get_db_session
 from src.api.dependencies.modal import get_modal_client
 from src.api.schemas.modal.invocations import (
@@ -35,7 +38,6 @@ async def invoke_modal_fn(
     user: User = Depends(authed_user),
     settings: Settings = Depends(get_settings),
     modal_client: modal.Client = Depends(get_modal_client),
-    modal_vip: bool = Depends(modal_vip),
     under_modal_usage_limit: bool = Depends(under_modal_usage_limit),
     db: AsyncSession = Depends(get_db_session),
 ):
@@ -111,7 +113,6 @@ async def invoke_modal_fn_async(
     user: User = Depends(authed_user),
     settings: Settings = Depends(get_settings),
     modal_client: modal.Client = Depends(get_modal_client),
-    modal_vip: bool = Depends(modal_vip),
     under_modal_usage_limit: bool = Depends(under_modal_usage_limit),
     db: AsyncSession = Depends(get_db_session),
 ):

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
-from src.api.dependencies.auth import authed_user, modal_vip
+from src.api.dependencies.auth import authed_user, in_modal_publishers_group
 from src.api.dependencies.database import get_db_session
 from src.api.dependencies.sandboxed_functions import (
     DeployModalAppProvider,
@@ -31,7 +31,7 @@ async def add_modal_app(
     settings: Settings = Depends(get_settings),
     validate_modal_file: ValidateModalFileProvider = validate_modal_file_dep,
     deploy_modal_app: DeployModalAppProvider = deploy_modal_app_dep,
-    modal_vip: bool = Depends(modal_vip),
+    in_modal_publishers_group: bool = Depends(in_modal_publishers_group),
 ):
     if not settings.MODAL_ENABLED:
         raise NotImplementedError("Garden's Modal integration has not been enabled")
@@ -122,7 +122,6 @@ async def delete_modal_app(
     db: AsyncSession = Depends(get_db_session),
     user: User = Depends(authed_user),
     settings: Settings = Depends(get_settings),
-    modal_vip: bool = Depends(modal_vip),
 ):
     # Get the modal app
     # see if it's deletable by the user

--- a/garden-backend-service/src/api/routes/modal/modal_functions.py
+++ b/garden-backend-service/src/api/routes/modal/modal_functions.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
-from src.api.dependencies.auth import authed_user, modal_vip
+from src.api.dependencies.auth import authed_user
 from src.api.dependencies.database import get_db_session
 from src.api.routes._utils import (
     assert_editable_by_user,
@@ -48,7 +48,6 @@ async def update_modal_function(
     db: AsyncSession = Depends(get_db_session),
     settings: Settings = Depends(get_settings),
     user: User = Depends(authed_user),
-    modal_vip: bool = Depends(modal_vip),
 ):
     log = logger.bind(id=id)
     modal_function: ModalFunction | None = await ModalFunction.get(db, id=id)

--- a/garden-backend-service/src/config.py
+++ b/garden-backend-service/src/config.py
@@ -70,6 +70,7 @@ class Settings(BaseSettings):
     MODAL_VIP_LIST: list[str]
     MODAL_USAGE_LIMIT: float = 5.0
     MODAL_TIMEOUT_SECONDS: float = 25.0
+    MODAL_PUBLISHERS_GROUP_ID: str = "84d1669a-9d51-11ef-8d7c-1769556b58bd"
 
     GARDEN_SEARCH_SQL_DIR: str = "src/api/search/sql.sql"
 

--- a/garden-backend-service/src/config.py
+++ b/garden-backend-service/src/config.py
@@ -67,7 +67,6 @@ class Settings(BaseSettings):
     MODAL_TOKEN_SECRET: str
     MODAL_ENV: str = "dev"
     MODAL_USE_LOCAL: bool = False
-    MODAL_VIP_LIST: list[str]
     MODAL_USAGE_LIMIT: float = 5.0
     MODAL_TIMEOUT_SECONDS: float = 25.0
     MODAL_PUBLISHERS_GROUP_ID: str = "84d1669a-9d51-11ef-8d7c-1769556b58bd"

--- a/garden-backend-service/src/config.py
+++ b/garden-backend-service/src/config.py
@@ -69,6 +69,7 @@ class Settings(BaseSettings):
     MODAL_USE_LOCAL: bool = False
     MODAL_USAGE_LIMIT: float = 5.0
     MODAL_TIMEOUT_SECONDS: float = 25.0
+    MODAL_VIP_LIST: list[str] = []
     MODAL_PUBLISHERS_GROUP_ID: str = "84d1669a-9d51-11ef-8d7c-1769556b58bd"
 
     GARDEN_SEARCH_SQL_DIR: str = "src/api/search/sql.sql"

--- a/garden-backend-service/tests/api/routes/modal/test_invocations.py
+++ b/garden-backend-service/tests/api/routes/modal/test_invocations.py
@@ -12,7 +12,6 @@ from src.api.schemas.modal.invocations import (
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_invoke_modal_fn(
-    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,
@@ -93,7 +92,6 @@ async def test_invoke_modal_fn(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_invoke_modal_fn_rejects_request_if_user_is_over_usage_limit(
-    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,
@@ -163,7 +161,6 @@ async def test_invoke_modal_fn_rejects_request_if_user_is_over_usage_limit(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_invoke_modal_fn_async(
-    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,

--- a/garden-backend-service/tests/api/routes/modal/test_invocations.py
+++ b/garden-backend-service/tests/api/routes/modal/test_invocations.py
@@ -14,7 +14,7 @@ from src.api.schemas.modal.invocations import (
 async def test_invoke_modal_fn(
     client,
     mock_db_session,
-    override_authenticated_dependency,
+    mock_modal_publisher_auth_state,
     override_get_settings_dependency,
     override_get_modal_client_dependency,
     mocker,
@@ -94,7 +94,7 @@ async def test_invoke_modal_fn(
 async def test_invoke_modal_fn_rejects_request_if_user_is_over_usage_limit(
     client,
     mock_db_session,
-    override_authenticated_dependency,
+    mock_modal_publisher_auth_state,
     override_get_settings_dependency,
     override_get_modal_client_dependency,
     mocker,
@@ -163,7 +163,7 @@ async def test_invoke_modal_fn_rejects_request_if_user_is_over_usage_limit(
 async def test_invoke_modal_fn_async(
     client,
     mock_db_session,
-    override_authenticated_dependency,
+    mock_modal_publisher_auth_state,
     override_get_settings_dependency,
     override_get_modal_client_dependency,
     mocker,

--- a/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
@@ -6,7 +6,7 @@ from tests.utils import post_modal_app
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_add_modal_app(
-    override_modal_vip,
+    override_publisher_group_membership,
     client,
     mock_db_session,
     override_authenticated_dependency,
@@ -46,7 +46,7 @@ async def test_add_modal_app(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_add_modal_app_with_class(
-    override_modal_vip,
+    override_publisher_group_membership,
     client,
     mock_db_session,
     override_authenticated_dependency,
@@ -73,7 +73,6 @@ async def test_add_modal_app_with_class(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_get_modal_app(
-    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,
@@ -102,7 +101,6 @@ async def test_get_modal_app(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_delete_modal_app(
-    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,

--- a/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
@@ -6,11 +6,9 @@ from tests.utils import post_modal_app
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_add_modal_app(
-    override_publisher_group_membership,
     client,
     mock_db_session,
-    override_authenticated_dependency,
-    mock_auth_state,
+    mock_modal_publisher_auth_state,
     mock_modal_app_create_request_one_function,
     override_sandboxed_functions,
 ):
@@ -21,7 +19,7 @@ async def test_add_modal_app(
     response_data = response.json()
     assert (
         response_data["app_name"]
-        == f"{mock_auth_state.identity_id}-"
+        == f"{mock_modal_publisher_auth_state.identity_id}-"
         + mock_modal_app_create_request_one_function["app_name"]
     )
     assert (
@@ -46,11 +44,9 @@ async def test_add_modal_app(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_add_modal_app_with_class(
-    override_publisher_group_membership,
     client,
     mock_db_session,
-    override_authenticated_dependency,
-    mock_auth_state,
+    mock_modal_publisher_auth_state,
     mock_modal_app_create_request_with_class,
     override_sandboxed_functions,
 ):
@@ -61,7 +57,7 @@ async def test_add_modal_app_with_class(
     response_data = response.json()
     assert (
         response_data["app_name"]
-        == f"{mock_auth_state.identity_id}-"
+        == f"{mock_modal_publisher_auth_state.identity_id}-"
         + mock_modal_app_create_request_with_class["app_name"]
     )
     assert (
@@ -75,8 +71,7 @@ async def test_add_modal_app_with_class(
 async def test_get_modal_app(
     client,
     mock_db_session,
-    override_authenticated_dependency,
-    mock_auth_state,
+    mock_modal_publisher_auth_state,
     mock_modal_app_create_request_one_function,
     override_sandboxed_functions,
 ):
@@ -89,7 +84,7 @@ async def test_get_modal_app(
     get_response_data = get_response.json()
     assert (
         get_response_data["app_name"]
-        == f"{mock_auth_state.identity_id}-"
+        == f"{mock_modal_publisher_auth_state.identity_id}-"
         + mock_modal_app_create_request_one_function["app_name"]
     )
     assert (
@@ -103,7 +98,7 @@ async def test_get_modal_app(
 async def test_delete_modal_app(
     client,
     mock_db_session,
-    override_authenticated_dependency,
+    mock_modal_publisher_auth_state,
     mock_modal_app_create_request_one_function,
     override_sandboxed_functions,
 ):

--- a/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
@@ -6,7 +6,6 @@ from tests.utils import post_modal_app
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_get_modal_function(
-    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,
@@ -30,7 +29,6 @@ async def test_get_modal_function(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_patch_modal_function_partial_update(
-    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,

--- a/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
@@ -8,7 +8,7 @@ from tests.utils import post_modal_app
 async def test_get_modal_function(
     client,
     mock_db_session,
-    override_authenticated_dependency,
+    mock_modal_publisher_auth_state,
     mock_modal_app_create_request_one_function,
     override_sandboxed_functions,
 ):
@@ -31,7 +31,7 @@ async def test_get_modal_function(
 async def test_patch_modal_function_partial_update(
     client,
     mock_db_session,
-    override_authenticated_dependency,
+    mock_modal_publisher_auth_state,
     override_sandboxed_functions,
     mock_modal_app_create_request_one_function,
 ):

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -18,7 +18,7 @@ from src.api.dependencies.auth import (
     AuthenticationState,
     _get_auth_token,
     authenticated,
-    modal_vip,
+    in_modal_publishers_group,
 )
 from src.api.dependencies.database import init
 from src.api.dependencies.modal import get_modal_client
@@ -179,8 +179,8 @@ def override_sandboxed_functions(
 
 
 @pytest.fixture
-def override_modal_vip():
-    app.dependency_overrides[modal_vip] = lambda: True
+def override_publisher_group_membership():
+    app.dependency_overrides[in_modal_publishers_group] = lambda: True
     yield
     app.dependency_overrides.clear()
 
@@ -254,7 +254,6 @@ def mock_settings(db_url):
     mock_settings.MODAL_USE_LOCAL = True
     mock_settings.MODAL_ENABLED = True
     mock_settings.GARDEN_SEARCH_SQL_DIR = "src/api/search/sql.sql"
-    mock_settings.MODAL_VIP_LIST = []
     mock_settings.MODAL_USAGE_LIMIT = 5.0
     mock_settings.MODAL_TIMEOUT_SECONDS = 10.0
     return mock_settings

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -125,6 +125,23 @@ def override_authenticated_dependency(mock_auth_state):
 
 
 @pytest.fixture
+def override_publisher_group_membership():
+    app.dependency_overrides[in_modal_publishers_group] = lambda: True
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def mock_modal_publisher_auth_state(
+    override_authenticated_dependency,
+    override_publisher_group_membership,
+    mock_auth_state,
+):
+    """Gives mock auth state and overrides the relevant auth checks"""
+    return mock_auth_state
+
+
+@pytest.fixture
 def override_get_settings_dependency(mock_settings):
     app.dependency_overrides[get_settings] = lambda: mock_settings
     yield
@@ -176,13 +193,6 @@ def override_sandboxed_functions(
     override_deploy_modal_app_dependency, override_validate_modal_file_dependency
 ):
     return
-
-
-@pytest.fixture
-def override_publisher_group_membership():
-    app.dependency_overrides[in_modal_publishers_group] = lambda: True
-    yield
-    app.dependency_overrides.clear()
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #188 

## Overview

This PR adds a check for membership in the Modal publishers Globus Group to gate access to the publication routes.

## Discussion

This supersedes the previous hardcoded "Modal VIP List". It also narrows the gating down to the risky routes - the ones that are exec'ing user code.

## Testing

I tested manually on a protected route. (Confirming with one user identity in the group and another identity not in the group.) I also tweaked the affected unit tests to accommodate the auth changes.