### PR TITLE
hotfix: update modal publishing routes to use new group dependency, update CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches:
       - "*"
+  push:
+    branches:
+      - "dev"
+      - "main"
   workflow_dispatch:
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -100,7 +100,7 @@ async def add_modal_app_async(
     settings: Settings = Depends(get_settings),
     validate_modal_file: ValidateModalFileProvider = validate_modal_file_dep,
     deploy_modal_app: DeployModalAppProvider = deploy_modal_app_dep,
-    modal_vip: bool = Depends(modal_vip),
+    in_modal_publishers_group: bool = Depends(in_modal_publishers_group),
 ):
     if not settings.MODAL_ENABLED:
         raise NotImplementedError("Garden's Modal integration has not been enabled")

--- a/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
@@ -69,12 +69,12 @@ async def test_add_modal_app_with_class(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_add_modal_app_async(
-    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,
     mock_auth_state,
     mock_modal_app_create_request_one_function,
+    mock_modal_publisher_auth_state,
     override_sandboxed_functions,
 ):
     response = await client.post(
@@ -98,12 +98,12 @@ async def test_add_modal_app_async(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_add_modal_app_async_resolves_on_success(
-    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,
     mock_auth_state,
     mock_modal_app_create_request_one_function,
+    mock_modal_publisher_auth_state,
     override_sandboxed_functions,
 ):
     response = await client.post(


### PR DESCRIPTION
## Overview

After merging #204, I merged #203. There were no conflicts and the merge went fine -- or so I thought. I realized there were some changes from #204 that didn't make it into #203 that are causing some import errors. Specifically, I didn't catch the new `in_modal_publishers_group` dependency leading to import errors trying to import the old `modal_vip` dependency. This PR remedies the issue.

From this, I realized our CI workflow for running the test suite was not configured to rerun the tests when merging a PR into dev. This PR sets up the action to trigger on merges to main and dev, hopefully this will catch this kind of error in the future.