### PR TITLE
Define modal app overwriting behavior

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches:
       - "*"
+  push:
+    branches:
+      - "dev"
+      - "main"
   workflow_dispatch:
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -100,7 +100,7 @@ async def add_modal_app_async(
     settings: Settings = Depends(get_settings),
     validate_modal_file: ValidateModalFileProvider = validate_modal_file_dep,
     deploy_modal_app: DeployModalAppProvider = deploy_modal_app_dep,
-    modal_vip: bool = Depends(modal_vip),
+    in_modal_publishers_group: bool = Depends(in_modal_publishers_group),
 ):
     if not settings.MODAL_ENABLED:
         raise NotImplementedError("Garden's Modal integration has not been enabled")

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -16,7 +16,7 @@ from src.api.schemas.modal.modal_app import (
 from src.config import Settings, get_settings
 from src.exceptions.modal import ModalException
 from src.modal.utils import monitor_modal_deployment
-from src.models import ModalApp, User
+from src.models import ModalApp, ModalFunction, User
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/modal-apps")
@@ -66,6 +66,35 @@ async def add_modal_app(
 
     # If everything looks good, we will go on to deploy the App.
     prefixed_app_name = f"{user.identity_id}-{modal_app.app_name}"
+    model_dict = modal_app.model_dump(
+        exclude={
+            "modal_function_names",
+            "owner_identity_id",
+            "id",
+            "overwrite_existing",
+        },
+        exclude_unset=True,
+    )
+
+    if existing_modal_app := await ModalApp.get(
+        db, app_name=prefixed_app_name, user_id=user.id
+    ):
+        if modal_app.overwrite_existing:
+            for modal_fn in model_dict["modal_functions"]:
+                modal_fn["hardware_spec"] = metadata["functions"][
+                    modal_fn["function_name"]
+                ]
+            existing_modal_app.modal_functions = [
+                ModalFunction.from_dict(modal_fn)
+                for modal_fn in model_dict["modal_functions"]
+            ]
+            await db.commit()
+            return existing_modal_app
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Modal App with name: {modal_app.app_name} already exists. Set the 'overwrite_existing' parameter to 'true' to enable overwriting.",
+            )
 
     deploy_modal_app(
         {
@@ -77,9 +106,6 @@ async def add_modal_app(
         }
     )
 
-    model_dict = modal_app.model_dump(
-        exclude={"modal_function_names", "owner_identity_id", "id"}, exclude_unset=True
-    )
     model_dict["user_id"] = user.id
     model_dict["app_name"] = prefixed_app_name
     for modal_fn in model_dict["modal_functions"]:
@@ -123,10 +149,37 @@ async def add_modal_app_async(
 
     # If everything looks good, we will go on to deploy the App.
     prefixed_app_name = f"{user.identity_id}-{modal_app.app_name}"
-
     model_dict = modal_app.model_dump(
-        exclude={"modal_function_names", "owner_identity_id", "id"}, exclude_unset=True
+        exclude={
+            "modal_function_names",
+            "owner_identity_id",
+            "id",
+            "overwrite_existing",
+        },
+        exclude_unset=True,
     )
+
+    if existing_modal_app := await ModalApp.get(
+        db, app_name=prefixed_app_name, user_id=user.id
+    ):
+        if modal_app.overwrite_existing:
+            for modal_fn in model_dict["modal_functions"]:
+                modal_fn["hardware_spec"] = metadata["functions"][
+                    modal_fn["function_name"]
+                ]
+            existing_modal_app.modal_functions = [
+                ModalFunction.from_dict(modal_fn)
+                for modal_fn in model_dict["modal_functions"]
+            ]
+            await db.commit()
+            return existing_modal_app
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Modal App with name: {modal_app.app_name} already exists. Set the 'overwrite_existing' parameter to 'true' to enable overwriting.",
+            )
+
+    # Deploy the new modal app
     model_dict["user_id"] = user.id
     model_dict["app_name"] = prefixed_app_name
     for modal_fn in model_dict["modal_functions"]:

--- a/garden-backend-service/src/api/schemas/modal/modal_app.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_app.py
@@ -20,6 +20,9 @@ class ModalAppMetadata(BaseSchema):
 class ModalAppCreateRequest(ModalAppMetadata):
     owner_identity_id: str | None = None
     modal_functions: list[ModalFunctionMetadata] = Field(default_factory=list)
+    overwrite_existing: bool = Field(
+        default=True, description="Overwrite an existing Modal App with the same same."
+    )
 
 
 class ModalAppMetadataResponse(ModalAppMetadata):

--- a/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
@@ -66,6 +66,41 @@ async def test_add_modal_app_with_class(
     )
 
 
+@pytest.mark.parametrize("post_url", ["/modal-apps", "/modal-apps/async"])
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_add_modal_app_overwrite_behavior(
+    client,
+    mock_db_session,
+    mock_modal_publisher_auth_state,
+    mock_modal_app_create_request_one_function,
+    override_sandboxed_functions,
+    post_url,
+):
+    # Post a modal app
+    response = await client.post(
+        post_url,
+        json=mock_modal_app_create_request_one_function,
+    )
+    assert response.status_code == 200
+
+    # Default behavior is to overwrite, a second post should succeed
+    response = await client.post(
+        post_url,
+        json=mock_modal_app_create_request_one_function,
+    )
+    assert response.status_code == 200
+
+    # Forbid overwriting, another post should error
+    create_request_no_overwrite = mock_modal_app_create_request_one_function
+    create_request_no_overwrite["overwrite_existing"] = False
+    error_response = await client.post(
+        post_url,
+        json=create_request_no_overwrite,
+    )
+    assert error_response.status_code == 409
+
+
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_add_modal_app_async(

--- a/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
@@ -69,12 +69,12 @@ async def test_add_modal_app_with_class(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_add_modal_app_async(
-    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,
     mock_auth_state,
     mock_modal_app_create_request_one_function,
+    mock_modal_publisher_auth_state,
     override_sandboxed_functions,
 ):
     response = await client.post(
@@ -98,12 +98,12 @@ async def test_add_modal_app_async(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_add_modal_app_async_resolves_on_success(
-    override_modal_vip,
     client,
     mock_db_session,
     override_authenticated_dependency,
     mock_auth_state,
     mock_modal_app_create_request_one_function,
+    mock_modal_publisher_auth_state,
     override_sandboxed_functions,
 ):
     response = await client.post(

--- a/garden-backend-service/tests/fixtures/ModalAppCreateRequest-one-function.json
+++ b/garden-backend-service/tests/fixtures/ModalAppCreateRequest-one-function.json
@@ -1,23 +1,23 @@
 {
-    "app_name": "test-app",
-    "modal_function_names": ["predict_iris_type"],
-    "version": "0.0.1",
-    "requirements": ["sklearn==0.24.2"],
-    "file_contents": "import modal\napp = modal.App('test-app')\n@app.function()\ndef predict_iris_type():\n    return 'Iris-setosa'",
-    "base_image_name": "python:3.11-slim",
-    "modal_functions": [
-        {
-            "year": "2024",
-            "authors": ["John Doe"],
-            "tags": [],
-            "test_functions": [],
-            "description": "tells you what flower you are looking at",
-            "title": "Iris Predictor",
-            "is_archived": false,
-            "function_name": "predict_iris_type",
-            "function_text": "def predict_iris_type():\n    return 'Iris-setosa'",
-            "doi": null
-        }
-    ],
-    "is_archived": false
+  "app_name": "test-app",
+  "modal_function_names": ["predict_iris_type"],
+  "version": "0.0.1",
+  "requirements": ["sklearn==0.24.2"],
+  "file_contents": "import modal\napp = modal.App('test-app')\n@app.function()\ndef predict_iris_type():\n    return 'Iris-setosa'",
+  "base_image_name": "python:3.11-slim",
+  "modal_functions": [
+    {
+      "year": "2024",
+      "authors": ["John Doe"],
+      "tags": [],
+      "test_functions": [],
+      "description": "tells you what flower you are looking at",
+      "title": "Iris Predictor",
+      "is_archived": false,
+      "function_name": "predict_iris_type",
+      "function_text": "def predict_iris_type():\n    return 'Iris-setosa'",
+      "doi": null
+    }
+  ],
+  "is_archived": false
 }


### PR DESCRIPTION
Resolves: #199 

## Overview

This PR defines our modal app overwriting behavior. By default, we follow Modal's lead to overwrite apps with the same name. This is controlled by a new parameter on the POST request called `overwrite_existing` which defaults to `true`. If a request comes in where this field is `false` and the app name conflicts with an existing app, the route returns a 409 error.

## Discussion

We can easily change this behavior by changing the default for the `overwrite_existing` field of the create request. 

## Testing

New tests!