### PR TITLE
Fix FunctionSpec serialization issue

### DIFF
--- a/garden-backend-service/src/sandboxed_functions/lambda_function.py
+++ b/garden-backend-service/src/sandboxed_functions/lambda_function.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import Any, TypedDict
 
 import modal
@@ -64,18 +63,19 @@ def get_function_specs(
     This behavior alerts us if/when Modal changes their `_FunctionSpec` schema
     """
     return {
-        name: extract_from_dict(dataclasses.asdict(func.spec), specs)
-        for name, func in functions.items()
+        name: extract_from_spec(func.spec, specs) for name, func in functions.items()
     }
 
 
-def extract_from_dict(d: dict[str, Any], keys: list[str]) -> dict[str, Any]:
+def extract_from_spec(
+    spec: modal.functions._FunctionSpec, keys: list[str]
+) -> dict[str, Any]:
     """Return a new dict with only the keys matching the given list.
 
     Raises `ModalException` when a given key is not present in `d`
     """
     try:
-        return {key: d[key] for key in keys}
+        return {key: getattr(spec, key) for key in keys}
     except Exception:
         raise ModalException(
             detail="Failed to parse function hardware spec.",

--- a/garden-backend-service/src/sandboxed_functions/lambda_function.py
+++ b/garden-backend-service/src/sandboxed_functions/lambda_function.py
@@ -72,7 +72,7 @@ def extract_from_spec(
 ) -> dict[str, Any]:
     """Return a new dict with only the keys matching the given list.
 
-    Raises `ModalException` when a given key is not present in `d`
+    Raises `ModalException` when a given key is not present in `spec`
     """
     try:
         return {key: getattr(spec, key) for key in keys}


### PR DESCRIPTION
Fixes #210 

## Overview

This PR tweaks the way we extract metadata on CPU, GPU, RAM usage from Modal functions to avoid an issue where we accidentally try (and fail) to serialize an IO Loop.

## Discussion

## Testing

Tested manually. Maintained same interface/behavior for `get_function_specs`, so existing unit tests apply.