### PR TITLE
Another pass at internal modal app name generation

### DIFF
--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -227,8 +227,31 @@ def _validate_modal_app_metadata_helper(
 
 
 def _generate_app_name(user: User, app_name: str) -> str:
+    """Generate a unique app name for deployment to Modal.
+
+    The app names look like: <user_id>-<app_name>-<unique-suffix>
+
+    Note: Modal limits app names to 64 characters. To give our users
+    the freedom to name their apps within Modal's guidelines, this function
+    will truncate the user supplied app name to fit within the size limit before
+    we deploy to our Modal environment.
+    """
+    modal_max_app_name_size = 64
+    prefix_len = len(str(user.identity_id))
+    suffix_len = 8
+    max_app_name_len = modal_max_app_name_size - (
+        prefix_len + suffix_len + 2  # 2 for separators
+    )
+
+    # truncate the app name if it is too long
+    app_name = (
+        app_name if len(app_name) < max_app_name_len else app_name[:max_app_name_len]
+    )
     prefixed_app_name = f"{user.identity_id}-{app_name}"
-    full_app_name = f"{prefixed_app_name}-{str(uuid4())}"
+
+    # generate a unique suffix
+    suffix = str(uuid4())[:suffix_len]
+    full_app_name = f"{prefixed_app_name}-{suffix}"
     return full_app_name
 
 

--- a/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
@@ -1,5 +1,6 @@
 import pytest
 
+from src.api.routes.modal.modal_apps import _generate_app_name
 from tests.utils import post_modal_app
 
 
@@ -166,3 +167,20 @@ async def test_delete_modal_app(
     response = await client.delete(f"/modal-apps/{app_id}")
     assert response.status_code == 200
     assert response.json() == {"detail": f"No Modal App found with id {app_id}."}
+
+
+def test_generate_app_names(mock_auth_state):
+    user = mock_auth_state
+    size_limit = 64
+    num_to_gen = 100
+
+    # maximum app name length on modal
+    app_name = "a" * size_limit
+    # generate a bunch of names using the same user and app name
+    generated_names = [_generate_app_name(user, app_name) for _ in range(num_to_gen)]
+
+    # assert they are all within the size limit
+    assert all(map(lambda app_name: len(app_name) <= size_limit, generated_names))
+
+    # assert there are no duplicates
+    assert len(set(generated_names)) == num_to_gen


### PR DESCRIPTION
Resolves: #218 

## Overview

This PR fixes a small issue I ran into where our generated modal app names hit modal's size limit of 64 characters.

When publishing a modal app `app = modal.App("iris-classifier")` I got this deployment error:
```
Invalid App name: 'e9a17e09-657b-4087-a719-241ab72b1d9b-iris-classifier-32949b7e-bbc4-4b5c-8f81-511b28a0e8f4'.

Names may contain only alphanumeric characters, dashes, periods, and underscores, must be shorter than 64 characters, and cannot conflict with App ID strings.
```

## Discussion

Updated the logic in the `_generate_app_name` helper to enforce the app name size constraint transparently from the users perspective. Our users can name their app anything that is valid on Modal. If the name is too large after we add the prefix and unique suffix, the user provided app name is truncated to fit within the size limit. This gives us the unique names we need internally, but doesn't affect the user experience.

## Testing

Added a new unit test to verify this behavior
