### PR TITLE
Make postgres init job acquire lock to avoid conflict

### DIFF
--- a/garden-backend-service/src/api/dependencies/database.py
+++ b/garden-backend-service/src/api/dependencies/database.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import sqlparse
@@ -5,8 +6,36 @@ from fastapi import Depends
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session
+from structlog import get_logger
 
 from src.config import get_settings
+
+log = get_logger(__name__)
+
+SEARCH_SQL_INIT_LOCK_ID = 20250117  # YYYYMMDD when implemented
+
+
+@asynccontextmanager
+async def advisory_lock(db: AsyncSession):
+    """Manage a Postgres advisory lock in an async context
+
+    Usage:
+        async with advisory_lock(db, DBLock.SEARCH_SQL_INIT) as locked:
+            if locked:
+                # Do protected operations
+    """
+    # Try to acquire lock without waiting
+    result = await db.execute(
+        text(f"SELECT pg_try_advisory_lock({SEARCH_SQL_INIT_LOCK_ID})")
+    )
+    lock_acquired = result.scalar()
+    try:
+        yield lock_acquired
+    finally:
+        if lock_acquired:
+            await db.execute(
+                text(f"SELECT pg_advisory_unlock({SEARCH_SQL_INIT_LOCK_ID})")
+            )
 
 
 async def async_init(db_session: async_sessionmaker, sql_path: Path):
@@ -14,10 +43,17 @@ async def async_init(db_session: async_sessionmaker, sql_path: Path):
     with open(sql_path, "r") as f:
         raw_sql = f.read()
     statements = sqlparse.split(raw_sql)
+
     async with db_session() as db:
-        for stmt in statements:
-            await db.execute(text(stmt))
-        await db.commit()
+        async with advisory_lock(db) as locked:
+            if not locked:
+                log.debug("Search SQL initialization already in progress")
+                return
+
+            for stmt in statements:
+                await db.execute(text(stmt))
+            await db.commit()
+            log.info("Search SQL initialization completed successfully")
 
 
 def init(db: Session, sql_path: Path):


### PR DESCRIPTION
Fast follow to #222. App init was failing when multiple workers all tried to do indexing to prep for search requests. This adds a lock acquisition so that only one worker does it