### PR TITLE
fix: send modal traceback data 

### DIFF
--- a/garden-backend-service/src/api/routes/modal/invocations.py
+++ b/garden-backend-service/src/api/routes/modal/invocations.py
@@ -253,16 +253,20 @@ async def get_modal_invocation_output(
 
     if inv.status is AsyncModalJobStatus.DONE and inv.output:
         parsed_output = api_pb2.FunctionGetOutputsItem.FromString(inv.output)
+        modal_result = parsed_output.result
         modal_result_data = {
-            "status": parsed_output.result.status,
-            "exception": parsed_output.result.exception,
+            "status": modal_result.status,
+            "exception": modal_result.exception,
+            "traceback": modal_result.traceback,
+            "serialized_tb": modal_result.serialized_tb,
+            "tb_line_cache": modal_result.tb_line_cache,
         }
         # handle either inline data or blob references
-        if parsed_output.result.HasField("data"):
+        if modal_result.HasField("data"):
             modal_result_data["data"] = parsed_output.result.data
-        elif parsed_output.result.HasField("data_blob_id"):
+        elif modal_result.HasField("data_blob_id"):
             modal_result_data["data_blob_url"] = await _get_blob_download_url(
-                modal_client, parsed_output.result.data_blob_id
+                modal_client, modal_result.data_blob_id
             )
 
         response_data["result"] = _ModalGenericResult(**modal_result_data)

--- a/garden-backend-service/src/api/schemas/modal/invocations.py
+++ b/garden-backend-service/src/api/schemas/modal/invocations.py
@@ -13,8 +13,8 @@ class _ModalGenericResult(BaseSchema):
     status: int
     exception: str = ""
     traceback: str = ""
-    serialized_tb: B64Bytes = b""
-    tb_line_cache: B64Bytes = b""
+    serialized_tb: B64Bytes | None = b""
+    tb_line_cache: B64Bytes | None = b""
     data: B64Bytes | None = b""
     # NOTE: this differs from the protobuf spec in that we send the full data_blob_url to
     # the garden client instead of data_blob_id (need active modal credentials to

--- a/garden-backend-service/src/api/schemas/modal/invocations.py
+++ b/garden-backend-service/src/api/schemas/modal/invocations.py
@@ -26,9 +26,6 @@ class _ModalGenericResult(BaseSchema):
         assert (
             self.data or self.data_blob_url
         ), "At least one of data or data_blob_url should be set."
-        assert not (
-            self.data and self.data_blob_url
-        ), "Only one of data or data_blob_url should be set."
         return self
 
 
@@ -42,9 +39,6 @@ class ModalInvocationRequest(BaseSchema):
         assert (
             self.args_kwargs_serialized or self.args_blob_id
         ), "At least one of args_kwargs_serialized or args_blob_id should be set."
-        assert not (
-            self.args_kwargs_serialized and self.args_blob_id
-        ), "Only one of args_kwargs_serialized or args_blob_id should be set."
         return self
 
 


### PR DESCRIPTION
(with companion sdk PR) fixes #221 

## Overview

We had the schema fields for propagating modal tracebacks as well as actual results, we just weren't populating them. This fixes that, so now the garden SDK can process/display remote exceptions for users the same way `modal run` would show them. 

## Testing

just manual testing