### PR TITLE
add file contents to ModalFunction schema/model

### DIFF
--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -50,7 +50,7 @@ async def add_modal_app(
         db, modal_app, user, full_app_name, hardware_specs
     )
 
-    _deploy_modal_app_helper(deploy_modal_app, full_app_name, modal_app, settings)
+    await _deploy_modal_app_helper(deploy_modal_app, full_app_name, modal_app, settings)
 
     return modal_app_db_model
 
@@ -281,6 +281,9 @@ async def _save_modal_app_to_db(
     for modal_fn in model_dict["modal_functions"]:
         name = modal_fn["function_name"]
         modal_fn["hardware_spec"] = hardware_specs[name]
+        if "file_contents" in modal_fn:
+            # redundant with app contents but part of schema
+            del modal_fn["file_contents"]
 
     modal_app_db_model = ModalApp.from_dict(model_dict)
     db.add(modal_app_db_model)

--- a/garden-backend-service/src/api/routes/modal/modal_file_metadata.py
+++ b/garden-backend-service/src/api/routes/modal/modal_file_metadata.py
@@ -36,6 +36,7 @@ async def parse_modal_file_metadata(
         meta = ModalFunctionMetadata(
             function_name=fn.function_name,
             function_text=fn.function_text,
+            file_contents=request.file_contents,
             title=fn.function_name,
             description=None,
             year=str(datetime.now().year),

--- a/garden-backend-service/src/api/schemas/modal/modal_function.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_function.py
@@ -6,6 +6,7 @@ from ..shared_function_schemas import CommonFunctionMetadata, CommonFunctionPatc
 class ModalFunctionMetadata(CommonFunctionMetadata):
     # Equivalent to "short_name" on entrypoints
     function_name: str
+    file_contents: str | None = None
     # Modal functions get a DOI when they are published
     # If they don't have a DOI, they are in draft state
     doi: str | None = None

--- a/garden-backend-service/src/models/modal/modal_function.py
+++ b/garden-backend-service/src/models/modal/modal_function.py
@@ -55,3 +55,7 @@ class ModalFunction(Base):
     @property
     def owner(self) -> User:
         return self.modal_app.owner
+
+    @property
+    def file_contents(self) -> str:
+        return self.modal_app.file_contents

--- a/infra/modules/lightsail/deployment-config.json
+++ b/infra/modules/lightsail/deployment-config.json
@@ -13,7 +13,7 @@
     "containerPort": 80,
     "healthCheck": {
       "healthyThreshold": 3,
-      "unhealthyThreshold": 3,
+      "unhealthyThreshold": 5,
       "timeoutSeconds": 5,
       "intervalSeconds": 30,
       "path": "/"


### PR DESCRIPTION

## Overview

This PR adds file_contents to the ModalFunction schema and to the db model (as a `@property`, so no migration should be necessary for existing modal functions) 

## Discussion


## Testing

🤠 