### PR TITLE
feat: local_entrypoints populate `test_functions` for functions they call 

### DIFF
--- a/garden-backend-service/src/api/routes/modal/modal_file_metadata.py
+++ b/garden-backend-service/src/api/routes/modal/modal_file_metadata.py
@@ -38,11 +38,14 @@ async def parse_modal_file_metadata(
             function_text=fn.function_text,
             file_contents=request.file_contents,
             title=fn.function_name,
-            description=None,
+            description=fn.function_desc,
             year=str(datetime.now().year),
             requirements=fn.image.pip_requirements,
             conda_requirements=fn.image.conda_requirements,
         )
+        for local_ep in results.local_entrypoints:
+            if fn.function_name in local_ep.called_functions:
+                meta.test_functions += [local_ep.function_text]
         function_metas += [meta]
 
     if len(results.apps) != 1:

--- a/garden-backend-service/src/api/schemas/modal/modal_app.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_app.py
@@ -35,7 +35,7 @@ class ModalAppMetadataResponse(ModalAppMetadata):
 
     @computed_field
     @property
-    def modal_function_ids(self) -> list[str]:
+    def modal_function_ids(self) -> list[int]:
         return [mf.id for mf in self.modal_functions]
 
 

--- a/garden-backend-service/src/modal/user_file_parsing.py
+++ b/garden-backend-service/src/modal/user_file_parsing.py
@@ -437,6 +437,7 @@ def try_parse_class_function_info(
                         function_info = ModalFunctionInfo(
                             function_name=f"{class_name}.{method_name}",
                             function_text=ast.unparse(method),
+                            function_desc=ast.get_docstring(method) or "",
                             app=app_info,
                             image=class_image,
                         )

--- a/garden-backend-service/src/modal/user_file_parsing.py
+++ b/garden-backend-service/src/modal/user_file_parsing.py
@@ -504,34 +504,3 @@ def _update_entrypoint_info_from_decorator(
             ) if f"{class_name}.{method_name}" in known_function_names:
                 ep_info.called_functions |= {f"{class_name}.{method_name}"}
     return ep_info
-
-
-def _parse_hardware_kwarg(node: ast.keyword):
-    # TODO remove if not needed
-    if node.arg in {"cpu", "memory"}:
-        match node.value:
-            case ast.Constant(value=val):
-                return val
-            case ast.Tuple(elts=[ast.Constant(value=val1), ast.Constant(value=val2)]):
-                return (val1, val2)
-    elif node.arg == "gpu":
-        match node.value:
-            case ast.Constant(value=val):
-                return val
-            case ast.List(elts=elts):
-                values = []
-                for element in elts:
-                    if isinstance(element, ast.Constant):
-                        # if it's a constant str or None, just include it
-                        gpu_key = element.value
-                    elif isinstance(element, ast.Name):
-                        # like `gpu=A100` instead of `gpu="A100"`
-                        # we persist it as the string instead since it's equivalent
-                        gpu_key = element.id
-                    elif isinstance(element, ast.Attribute):
-                        # like `gpu=modal.gpu.A100` or `gpu=modal.gpu.A100()`
-                        # best effort without exec-ing anything
-                        string_rep = ast.unparse(element)
-                        gpu_key = string_rep.split(".")[-1].strip("()")
-                    values += [gpu_key]
-                return values

--- a/garden-backend-service/src/modal/user_file_parsing.py
+++ b/garden-backend-service/src/modal/user_file_parsing.py
@@ -62,12 +62,16 @@ class ModalAppInfo:
 class ModalFunctionInfo:
     function_name: str
     function_text: str
+    function_desc: str
     app: ModalAppInfo
     image: ModalImageInfo
-    hardware_spec: dict = field(
-        default_factory=dict
-    )  # ^should be same shape the estimate_usage helper expects
-    # TODO remove hardware_spec if not needed
+
+
+@dataclass
+class ModalLocalEntrypointInfo:
+    function_name: str
+    function_text: str
+    called_functions: set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -75,6 +79,7 @@ class ModalFileParseResults:
     images: list[ModalImageInfo] = field(default_factory=list)
     apps: list[ModalAppInfo] = field(default_factory=list)
     functions: list[ModalFunctionInfo] = field(default_factory=list)
+    local_entrypoints: list[ModalLocalEntrypointInfo] = field(default_factory=list)
 
 
 def parse_modal_file(contents: str) -> ModalFileParseResults:
@@ -95,6 +100,7 @@ def parse_modal_file(contents: str) -> ModalFileParseResults:
     images = {}
     apps = {}
     functions = {}
+    local_entrypoints = []
 
     for node in tree.body:
         match node:
@@ -123,6 +129,12 @@ def parse_modal_file(contents: str) -> ModalFileParseResults:
             ):
                 for function_info in class_function_infos:
                     functions[function_info.function_name] = function_info
+            case (
+                ast.FunctionDef() as local_ep_def
+            ) if local_entrypoint_info := try_parse_local_entrypoint_info(
+                local_ep_def, functions
+            ):
+                local_entrypoints += [local_entrypoint_info]
 
     if "app" not in apps:
         raise ModalException(
@@ -134,6 +146,7 @@ def parse_modal_file(contents: str) -> ModalFileParseResults:
         images=list(images.values()),
         apps=list(apps.values()),
         functions=list(functions.values()),
+        local_entrypoints=local_entrypoints,
     )
 
 
@@ -330,6 +343,7 @@ def try_parse_function_info(
             function_info = ModalFunctionInfo(
                 function_name=function_name,
                 function_text=ast.unparse(node),
+                function_desc=ast.get_docstring(node) or "",
                 app=app_info,
                 image=app_info.image,  # default is app image, but decorator kwarg takes priority
             )
@@ -359,8 +373,6 @@ def _update_function_info_from_decorator(
                 # handle case where kwarg is `image=modal.Image.<chained_image_methods>`
                 image_info = try_parse_image_info(kw.value)
                 func_info.image = image_info
-            case ast.keyword(arg=arg) if arg in {"cpu", "gpu", "memory"}:
-                func_info.hardware_spec[arg] = _parse_hardware_kwarg(kw)
             case ast.keyword(arg="name", value=ast.Constant(value=str(new_name))):
                 func_info.function_name = new_name
             case ast.keyword(arg=arg) if arg in FUNCTION_KWARG_BLOCKLIST:
@@ -433,6 +445,65 @@ def try_parse_class_function_info(
             return functions or None
         case _:
             return None
+
+
+def try_parse_local_entrypoint_info(
+    node: ast.FunctionDef,
+    parsed_functions: dict[str, ModalFunctionInfo] | None = None,
+) -> ModalLocalEntrypointInfo | None:
+    parsed_functions = parsed_functions or {}
+    match node:
+        case ast.FunctionDef(name=entrypoint_name) if _is_decorated_local_entrypoint(
+            node
+        ):
+            entrypoint_info = ModalLocalEntrypointInfo(
+                function_name=entrypoint_name,
+                function_text=ast.unparse(node),
+            )
+            return _update_entrypoint_info_from_decorator(
+                node, entrypoint_info, set(parsed_functions.keys())
+            )
+        case _:
+            return None
+
+
+def _is_decorated_local_entrypoint(node: ast.FunctionDef) -> bool:
+    """Check if a function node is decorated like @<some_app>.local_entrypoint."""
+    for decorator in node.decorator_list:
+        match decorator:
+            case ast.Call(ast.Attribute(attr="local_entrypoint")):
+                return True
+    return False
+
+
+def _update_entrypoint_info_from_decorator(
+    fn_node: ast.FunctionDef,
+    info: ModalLocalEntrypointInfo,
+    known_function_names: set[str],
+) -> ModalLocalEntrypointInfo:
+    ep_info = copy.deepcopy(info)
+    # walk the function node's subtree for any Calls which match the name of a
+    # function (or method) we've already seen
+    for node in ast.walk(fn_node):
+        match node:
+            # case 1: function_name.remote()
+            case ast.Call(
+                func=ast.Attribute(
+                    value=ast.Name(id=called_function_name), attr="remote"
+                )
+            ) if called_function_name in known_function_names:
+                ep_info.called_functions |= {called_function_name}
+            # case 2: class_name.method_name.remote()
+            case ast.Call(
+                func=ast.Attribute(
+                    value=ast.Attribute(
+                        value=ast.Name(id=class_name), attr=method_name
+                    ),
+                    attr="remote",
+                )
+            ) if f"{class_name}.{method_name}" in known_function_names:
+                ep_info.called_functions |= {f"{class_name}.{method_name}"}
+    return ep_info
 
 
 def _parse_hardware_kwarg(node: ast.keyword):

--- a/garden-backend-service/tests/api/routes/modal/test_modal_file_metadata.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_file_metadata.py
@@ -11,6 +11,7 @@ from tests.fixtures.modal_file_constants import (
     VALID_CLASS_BASED,
     VALID_CONDA_PACKAGES,
     VALID_MULTIPLE_IMAGES,
+    VALID_MULTIPLE_LOCAL_ENTRYPOINTS,
     VALID_NO_CUSTOM_IMAGE,
 )
 
@@ -124,6 +125,36 @@ async def test_validate_class_based(client, _metadata_validation_fixtures):
     )
     for fn_info in data["modal_functions"]:
         assert "scikit-learn" in fn_info["requirements"]
+        assert len(fn_info["test_functions"]) == 1
+        assert (
+            "def main():" in fn_info["test_functions"][0]
+        )  # both have same local entrypoint
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_validate_multiple_local_entrypoints(
+    client, _metadata_validation_fixtures
+):
+    response = await client.post(
+        "/modal-file-metadata", json={"file_contents": VALID_MULTIPLE_LOCAL_ENTRYPOINTS}
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    # should have distinct local_entrypoints
+    assert (
+        data["modal_functions"][0]["test_functions"]
+        != data["modal_functions"][1]["test_functions"]
+    )
+
+    for fn_info in data["modal_functions"]:
+        assert len(fn_info["test_functions"]) == 1
+        test_fn = fn_info["test_functions"][0]
+        if fn_info["function_name"] == "science_stuff":
+            assert "science r u l e s" in test_fn
+        else:
+            assert "BILL! BILL! BILL! BILL!" in test_fn
 
 
 @pytest.mark.asyncio

--- a/garden-backend-service/tests/fixtures/modal_file_constants.py
+++ b/garden-backend-service/tests/fixtures/modal_file_constants.py
@@ -98,8 +98,39 @@ class Model:
     @modal.method()
     def predict_proba(self, x):
         return self.model.predict_proba(x)
+
+@app.local_entrypoint()
+def main():
+    Model.predict.remote("abc")
+    Model.predict_proba.remote("123")
 """
 
+# Valid case: Different local entrypoints for different functions
+VALID_MULTIPLE_LOCAL_ENTRYPOINTS = """
+import modal
+
+app = modal.App("science-app")
+
+@app.function()
+def science_stuff():
+    import numpy as np
+    return np.random.rand(10)
+
+@app.local_entrypoint()
+def test_science_stuff():
+    print(science_stuff.remote("science r u l e s"))
+
+@app.function()
+def ml_stuff():
+    import torch
+    return torch.rand(10)
+
+
+@app.local_entrypoint()
+def test_ml_stuff():
+    results = ml_stuff.remote("BILL! BILL! BILL! BILL!")
+    print(results)
+"""
 # Valid case: Using micromamba for conda packages
 VALID_CONDA_PACKAGES = """
 import modal


### PR DESCRIPTION
closes #227 

## Overview
Any `@local_entrypoint`s that appear to exercise a user's modal function in their uploaded file are now persisted as `ModalFunction.test_functions` so the frontend can showcase example usage. 

## Discussion

This is the first pass to just extract and persist local_entrypoint source code for modal function metadata. Future passes could implement the logic to bestow them with `example_usage` field that looks like what a garden user's typical invocation would, rather than just the local_entrypoint text.  

## Testing

extended the unit test for class-based functions, plus added a test with an edge case for multiple local_entrypoints that call distinct functions