### PR TITLE
Quick and dirty load tests

### DIFF
--- a/garden-backend-service/src/api/dependencies/auth.py
+++ b/garden-backend-service/src/api/dependencies/auth.py
@@ -1,10 +1,11 @@
 from datetime import datetime
+from typing import AsyncGenerator
 
 import globus_sdk
 import structlog
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import func, select
+from sqlalchemy import exc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
@@ -47,12 +48,31 @@ async def authed_user(
     db: AsyncSession = Depends(get_db_session),
     auth: AuthenticationState = Depends(authenticated),
     settings: Settings = Depends(get_settings),
-) -> User:
+) -> AsyncGenerator[User, None]:
     try:
-        user, created = await User.get_or_create(
-            db,
-            identity_id=auth.identity_id,
+        # First try to get the user
+        user = await db.scalar(
+            select(User).where(User.identity_id == auth.identity_id).limit(1)
         )
+
+        created = False
+        if user is None:
+            try:
+                # User doesn't exist, create them
+                user = User(identity_id=auth.identity_id)
+                db.add(user)
+                await db.flush()
+                created = True
+            except exc.IntegrityError:
+                # Another request created the user before us
+                await db.rollback()
+                user = await db.scalar(
+                    select(User).where(User.identity_id == auth.identity_id).limit(1)
+                )
+                if user is None:
+                    raise HTTPException(
+                        status_code=500, detail="Failed to create or retrieve user"
+                    )
 
         # Add the user to Garden Users Globus group if they are new
         if created:

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -1,3 +1,4 @@
+from typing import Any
 from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
@@ -89,7 +90,7 @@ async def add_modal_app_async(
         monitor_modal_deployment,
         deploy_modal_app,
         deploy_config,
-        modal_app_db_model,
+        modal_app_db_model.id,
         settings,
     )
 
@@ -266,7 +267,7 @@ async def _save_modal_app_to_db(
     modal_app: ModalAppCreateRequest,
     user: User,
     full_app_name: str,
-    hardware_specs: dict,
+    hardware_specs: dict[str, dict[str, Any]],
 ):
     model_dict = modal_app.model_dump(
         exclude={

--- a/garden-backend-service/src/api/schemas/modal/modal_app.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_app.py
@@ -35,7 +35,7 @@ class ModalAppMetadataResponse(ModalAppMetadata):
 
     @computed_field
     @property
-    def modal_function_ids(self) -> list[str]:
+    def modal_function_ids(self) -> list[int]:
         return [mf.id for mf in self.modal_functions]
 
 

--- a/garden-backend-service/src/middleware/logging.py
+++ b/garden-backend-service/src/middleware/logging.py
@@ -86,5 +86,5 @@ class ErrorHandlingMiddleware(BaseHTTPMiddleware):
             )
 
             return JSONResponse(
-                status_code=500, content={"detail": "Internal Server Error"}
+                status_code=500, content={"detail": f"Internal Server Error: {str(e)}"}
             )

--- a/garden-backend-service/src/modal/utils.py
+++ b/garden-backend-service/src/modal/utils.py
@@ -87,9 +87,9 @@ async def monitor_modal_invocation(
 
 
 async def monitor_modal_deployment(
-    deploy_func: Callable[..., Awaitable],
-    deploy_config: dict,
-    db_modal_app: ModalApp,
+    deploy_func: Callable[..., Awaitable[None]],
+    deploy_config: dict[str, str | bytes],
+    app_id: int,
     settings: Settings,
 ):
     session_maker = await get_db_session_maker(settings=settings)
@@ -97,12 +97,12 @@ async def monitor_modal_deployment(
     try:
         await deploy_func(deploy_config)
         async with session_maker() as session:
-            if modal_app := await ModalApp.get(session, id=db_modal_app.id):
+            if modal_app := await ModalApp.get(session, id=app_id):
                 modal_app.deploy_status = AsyncModalJobStatus.DONE
                 await session.commit()
     except Exception as e:
         async with session_maker() as session:
-            if modal_app := await ModalApp.get(session, id=db_modal_app.id):
+            if modal_app := await ModalApp.get(session, id=app_id):
                 modal_app.deploy_error = str(e)
                 modal_app.deploy_status = AsyncModalJobStatus.ERROR
                 await session.commit()

--- a/garden-backend-service/src/models/base.py
+++ b/garden-backend-service/src/models/base.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, Type, TypeVar
 
-from sqlalchemy import exc, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncAttrs, AsyncSession
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm.attributes import QueryableAttribute
@@ -24,32 +24,6 @@ class Base(AsyncAttrs, DeclarativeBase):
             q = q.order_by(getattr(cls, order_by).desc())
 
         return (await db.execute(q.limit(1))).scalar_one_or_none()
-
-    @classmethod
-    async def get_or_create(
-        cls: Type[T], db: AsyncSession, **kwargs: Any
-    ) -> tuple[T, bool]:
-        # First try to get the object
-        obj = await cls.get(db, **kwargs)
-        if obj is not None:
-            return obj, False
-
-        try:
-            # Object doesn't exist, try to create it
-            obj = cls(**kwargs)
-            db.add(obj)
-            await db.flush()
-            return obj, True
-        except exc.IntegrityError:
-            # If we hit an integrity error, someone else created the object
-            await db.rollback()
-            # Try to get the object again
-            obj = await cls.get(db, **kwargs)
-            if obj is None:
-                # In the very unlikely case that the object disappeared,
-                # try the whole operation once more
-                return await cls.get_or_create(db, **kwargs)
-            return obj, False
 
     async def _asave(self, db: AsyncSession) -> None:
         db.add(self)

--- a/garden-backend-service/src/models/base.py
+++ b/garden-backend-service/src/models/base.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, Type, TypeVar
 
-from sqlalchemy import select
+from sqlalchemy import exc, select
 from sqlalchemy.ext.asyncio import AsyncAttrs, AsyncSession
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm.attributes import QueryableAttribute
@@ -29,16 +29,27 @@ class Base(AsyncAttrs, DeclarativeBase):
     async def get_or_create(
         cls: Type[T], db: AsyncSession, **kwargs: Any
     ) -> tuple[T, bool]:
+        # First try to get the object
         obj = await cls.get(db, **kwargs)
-        created = False
+        if obj is not None:
+            return obj, False
 
-        if not obj:
+        try:
+            # Object doesn't exist, try to create it
             obj = cls(**kwargs)
-            await obj._asave(db)
-            await db.refresh(obj)
-            created = True
-
-        return obj, created
+            db.add(obj)
+            await db.flush()
+            return obj, True
+        except exc.IntegrityError:
+            # If we hit an integrity error, someone else created the object
+            await db.rollback()
+            # Try to get the object again
+            obj = await cls.get(db, **kwargs)
+            if obj is None:
+                # In the very unlikely case that the object disappeared,
+                # try the whole operation once more
+                return await cls.get_or_create(db, **kwargs)
+            return obj, False
 
     async def _asave(self, db: AsyncSession) -> None:
         db.add(self)

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -2,7 +2,7 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
@@ -10,6 +10,7 @@ import pytest
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPBearer
 from httpx import ASGITransport, AsyncClient
+from modal_proto import api_pb2
 from sqlalchemy import text
 from sqlalchemy.engine import create_engine
 from sqlalchemy.orm import Session
@@ -400,3 +401,76 @@ def mock_is_doi_registered(mocker):
     mock_garden.return_value = False
 
     return mock_garden
+
+
+@pytest.fixture
+def mock_modal_function() -> MagicMock:
+    """Fixture for mocking a Modal function"""
+    mock_function = MagicMock()
+    mock_function._invocation_function_id.return_value = "mock_function_id"
+    mock_function.spec.return_value = {"cpu": 0.125, "gpus": "A100", "memory": None}
+    return mock_function
+
+
+@pytest.fixture
+def mock_modal_invocation() -> AsyncMock:
+    """Fixture for mocking a Modal invocation with successful result"""
+    mock_invocation = AsyncMock()
+    mock_invocation.function_call_id = "mock_call_id"
+    # Mock successful output
+    mock_invocation.pop_function_call_outputs.return_value = MagicMock(
+        outputs=[
+            api_pb2.FunctionGetOutputsItem(
+                result=api_pb2.GenericResult(
+                    status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS,
+                    data=b"mock_result",
+                ),
+                data_format=api_pb2.DATA_FORMAT_PICKLE,
+            )
+        ]
+    )
+    return mock_invocation
+
+
+@pytest.fixture
+def modal_test_environment(
+    client: AsyncClient,
+    mocker,
+    mock_modal_function,
+    mock_modal_invocation,
+    override_publisher_group_membership,
+    override_authenticated_dependency,
+    override_sandboxed_functions,
+    override_get_settings_dependency,
+    override_get_modal_client_dependency,
+    mock_db_session,
+    mock_auth_state,
+):
+    """Composite fixture that sets up all dependencies needed for Modal testing.
+
+    This combines the most commonly used fixtures for Modal-related tests into a single fixture.
+    Returns a dictionary containing the initialized test client and other useful test objects.
+    """
+    return {
+        "client": client,
+        "mocker": mocker,
+        "mock_function": mock_modal_function,
+        "mock_invocation": mock_modal_invocation,
+        "auth_state": mock_auth_state,
+        "modal_client": override_get_modal_client_dependency,
+    }
+
+
+@pytest.fixture
+def modal_deployment_environment(
+    modal_test_environment: dict[str, Any],
+    mock_modal_app_create_request_one_function: dict[str, Any],
+):
+    """Composite fixture specifically for Modal deployment tests.
+
+    Extends modal_test_environment with deployment-specific fixtures and configuration.
+    """
+    return {
+        **modal_test_environment,
+        "app_request": mock_modal_app_create_request_one_function,
+    }

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 from pathlib import Path
 from typing import Optional
@@ -29,6 +30,15 @@ from src.api.dependencies.sandboxed_functions import (
 from src.config import Settings, get_settings
 from src.main import app
 from src.models.base import Base
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--num-concurrent-requests",
+        type=int,
+        default=os.getenv("GARDEN_TEST_NUM_CONCURRENT_REQUESTS", 30),
+        help="Number of concurrent requests to run in load tests.",
+    )
 
 
 @pytest.fixture
@@ -260,6 +270,11 @@ def mock_settings(db_url):
     mock_settings.MODAL_USAGE_LIMIT = 5.0
     mock_settings.MODAL_TIMEOUT_SECONDS = 10.0
     return mock_settings
+
+
+@pytest.fixture
+def num_concurrent_requests(request):
+    return request.config.getoption("--num-concurrent-requests")
 
 
 @pytest.fixture

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -149,13 +149,6 @@ def override_get_settings_dependency(mock_settings):
 
 
 @pytest.fixture
-def override_get_settings_dependency_with_sync(mock_settings_with_sync):
-    app.dependency_overrides[get_settings] = lambda: mock_settings_with_sync
-    yield
-    app.dependency_overrides.clear()
-
-
-@pytest.fixture
 def mock_validate_modal_file_provider(request):
     mock_provider = AsyncMock(spec=ValidateModalFileProvider)
     mock_provider.return_value = getattr(request, "param", None) or {
@@ -266,12 +259,6 @@ def mock_settings(db_url):
     mock_settings.GARDEN_SEARCH_SQL_DIR = "src/api/search/sql.sql"
     mock_settings.MODAL_USAGE_LIMIT = 5.0
     mock_settings.MODAL_TIMEOUT_SECONDS = 10.0
-    return mock_settings
-
-
-@pytest.fixture
-def mock_settings_with_sync(mock_settings):
-    mock_settings.SYNC_SEARCH_INDEX = True
     return mock_settings
 
 

--- a/garden-backend-service/tests/load_test.py
+++ b/garden-backend-service/tests/load_test.py
@@ -78,7 +78,7 @@ async def wait_for_deployment_status(
     client: AsyncClient,
     app_id: int,
     target_status: str,
-    timeout_seconds: float = 10.0,
+    timeout_seconds: float = 15.0,
     poll_interval_seconds: float = 0.5,
 ) -> Dict[str, Any]:
     """Wait for a modal app to reach the target deployment status"""

--- a/garden-backend-service/tests/load_test.py
+++ b/garden-backend-service/tests/load_test.py
@@ -1,9 +1,13 @@
 import asyncio
+import base64
 from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import AsyncClient
+from modal_proto import api_pb2
 
+from src.api.schemas.modal.invocations import ModalInvocationRequest
 from src.modal.status import AsyncModalJobStatus
 
 
@@ -94,11 +98,49 @@ async def wait_for_deployment_status(
         await asyncio.sleep(poll_interval_seconds)
 
 
+async def wait_for_invocation_status(
+    client: AsyncClient,
+    invocation_id: int,
+    target_status: str,
+    timeout_seconds: float = 10.0,
+    poll_interval_seconds: float = 0.5,
+) -> Dict[str, Any]:
+    """Wait for a modal invocation to reach the target status"""
+    start_time = asyncio.get_event_loop().time()
+    while True:
+        response = await client.get(f"/modal-invocations/{invocation_id}")
+        assert response.status_code == 200
+        invocation = response.json()
+
+        if invocation["status"] == target_status:
+            return invocation
+
+        if asyncio.get_event_loop().time() - start_time > timeout_seconds:
+            raise TimeoutError(
+                f"Timed out waiting for invocation {invocation_id} to reach status {target_status}. "
+                f"Current status: {invocation['status']}"
+            )
+
+        await asyncio.sleep(poll_interval_seconds)
+
+
+async def create_modal_invocation_request(
+    client: AsyncClient,
+    function_id: int,
+) -> Any:
+    """Helper function to create a modal invocation request"""
+    request_data = ModalInvocationRequest(
+        function_id=function_id,
+        args_kwargs_serialized=b"mock_input_data",
+    ).model_dump()
+    return await client.post("/modal-invocations/async", json=request_data)
+
+
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_concurrent_modal_deployments(
     client: AsyncClient,
-    monkeypatch,
+    mocker,
     override_publisher_group_membership,
     override_authenticated_dependency,
     override_sandboxed_functions,
@@ -108,12 +150,13 @@ async def test_concurrent_modal_deployments(
     mock_modal_app_create_request_one_function,
 ):
     # Mock the deployment and validation functions
-    monkeypatch.setattr(
-        "src.api.dependencies.sandboxed_functions.deploy_modal_app", mock_deploy
+    mocker.patch(
+        "src.api.dependencies.sandboxed_functions.deploy_modal_app",
+        side_effect=mock_deploy,
     )
-    monkeypatch.setattr(
+    mocker.patch(
         "src.api.dependencies.sandboxed_functions.validate_modal_file",
-        mock_validate_modal_file,
+        side_effect=mock_validate_modal_file,
     )
 
     # Create multiple apps concurrently
@@ -155,3 +198,97 @@ async def test_concurrent_modal_deployments(
     for app in final_apps:
         assert app["deploy_status"] == AsyncModalJobStatus.DONE.value
         assert app["deploy_error"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_concurrent_modal_invocations(
+    client: AsyncClient,
+    mocker,
+    override_publisher_group_membership,
+    override_authenticated_dependency,
+    override_sandboxed_functions,
+    override_get_settings_dependency,
+    override_get_modal_client_dependency,
+    mock_db_session,
+    mock_auth_state,
+    mock_modal_app_create_request_one_function,
+):
+    # Mock the deployment and validation functions first
+    mocker.patch(
+        "src.api.dependencies.sandboxed_functions.deploy_modal_app",
+        side_effect=mock_deploy,
+    )
+    mocker.patch(
+        "src.api.dependencies.sandboxed_functions.validate_modal_file",
+        side_effect=mock_validate_modal_file,
+    )
+
+    # Create a modal app with a function to invoke
+    response = await client.post(
+        "/modal-apps", json=mock_modal_app_create_request_one_function
+    )
+    assert response.status_code == 200
+    response_data = response.json()
+    function_id = response_data["modal_function_ids"][0]
+
+    # Mock the modal function lookup and invocation creation
+    mock_invocation = AsyncMock()
+    mock_invocation.function_call_id = "mock_call_id"
+    # Mock the pop_function_call_outputs to simulate a successful invocation
+    mock_outputs_response = MagicMock()
+    output_item = api_pb2.FunctionGetOutputsItem(
+        result=api_pb2.GenericResult(
+            status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS, data=b"mock_result"
+        ),
+        data_format=api_pb2.DATA_FORMAT_PICKLE,
+    )
+    mock_outputs_response.outputs = [output_item]
+    mock_invocation.pop_function_call_outputs.return_value = mock_outputs_response
+
+    mock_function = MagicMock()
+    mock_function._invocation_function_id.return_value = "mock_function_id"
+    mocker.patch("modal.functions._Function.lookup", return_value=mock_function)
+    mocker.patch(
+        "src.api.routes.modal.invocations._create_invocation",
+        return_value=mock_invocation,
+    )
+
+    # Create multiple invocations concurrently
+    num_invocations = 30
+    invocation_tasks = []
+    for _ in range(num_invocations):
+        task = create_modal_invocation_request(client, function_id)
+        invocation_tasks.append(task)
+
+    # Wait for all invocations to be created
+    responses = await asyncio.gather(*invocation_tasks)
+
+    # Verify all creations were successful and get invocation IDs
+    invocation_ids = []
+    for response in responses:
+        assert response.status_code == 200
+        invocation_data = response.json()
+        assert invocation_data["status"] == AsyncModalJobStatus.PENDING.value
+        invocation_ids.append(invocation_data["id"])
+
+    # Wait for all invocations to complete concurrently
+    completion_tasks = []
+    for invocation_id in invocation_ids:
+        task = wait_for_invocation_status(
+            client,
+            invocation_id,
+            AsyncModalJobStatus.DONE.value,
+            timeout_seconds=10.0,  # Longer timeout for concurrent invocations
+        )
+        completion_tasks.append(task)
+
+    # Wait for all invocations to finish
+    final_invocations = await asyncio.gather(*completion_tasks)
+
+    # Verify all invocations completed successfully
+    for invocation in final_invocations:
+        assert invocation["status"] == AsyncModalJobStatus.DONE.value
+        assert invocation["result"]["data"] == base64.b64encode(b"mock_result").decode(
+            "utf-8"
+        )

--- a/garden-backend-service/tests/load_test.py
+++ b/garden-backend-service/tests/load_test.py
@@ -1,0 +1,89 @@
+import asyncio
+from typing import Any, Dict
+
+import pytest
+from httpx import AsyncClient
+
+
+def create_modal_file_contents(app_name: str, function_name: str) -> str:
+    """Create Modal file contents with matching app name and function name"""
+    return f"""
+import modal
+
+app = modal.App(name="{app_name}", image=modal.Image.debian_slim(python_version="3.12"))
+
+@app.function()
+def {function_name}():
+    return "Hello from Modal!"
+"""
+
+
+async def create_modal_app_request(
+    client: AsyncClient,
+    app_name: str,
+    mock_modal_app_create_request_one_function: Dict[str, Any],
+):
+    """Helper function to create a modal app deployment request"""
+    # Use the mock request as base and override specific fields
+    request_data = mock_modal_app_create_request_one_function.copy()
+    function_name = request_data["modal_functions"][0]["function_name"]
+
+    # Update app name and file contents consistently
+    request_data["app_name"] = app_name
+    request_data["file_contents"] = create_modal_file_contents(app_name, function_name)
+    return await client.post("/modal-apps/async", json=request_data)
+
+
+async def get_modal_app(client: AsyncClient, app_id: int) -> Dict[str, Any]:
+    """Helper function to get modal app details"""
+    response = await client.get(f"/modal-apps/{app_id}")
+    assert response.status_code == 200
+    return response.json()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_concurrent_modal_deployments(
+    client: AsyncClient,
+    mock_db_session,
+    mock_auth_state,
+    override_authenticated_dependency,
+    override_sandboxed_functions,
+    override_publisher_group_membership,
+    mock_modal_app_create_request_one_function,
+):
+    """Test that multiple concurrent modal deployments work correctly"""
+    num_concurrent = 10
+    tasks = []
+
+    for i in range(num_concurrent):
+        app_name = f"test-app-{i}"
+        tasks.append(
+            create_modal_app_request(
+                client,
+                app_name,
+                mock_modal_app_create_request_one_function,
+            )
+        )
+
+    try:
+        responses = await asyncio.gather(*tasks)
+        for i, response in enumerate(responses):
+            print(f"Response {i}: {response.status_code}")
+            assert response.status_code == 200
+
+        # Verify each response has a unique app ID
+        app_ids = [response.json()["id"] for response in responses]
+        assert len(set(app_ids)) == num_concurrent
+
+        # Verify app states
+        get_tasks = [get_modal_app(client, app_id) for app_id in app_ids]
+        apps = await asyncio.gather(*get_tasks)
+
+        # All apps should be in either pending or done state
+        for app in apps:
+            assert app["deploy_status"] in ["pending", "done"]
+
+    except Exception as e:
+        print(f"Error during concurrent requests: {str(e)}")
+        raise

--- a/garden-backend-service/tests/load_test.py
+++ b/garden-backend-service/tests/load_test.py
@@ -148,6 +148,7 @@ async def test_concurrent_modal_deployments(
     mock_db_session,
     mock_auth_state,
     mock_modal_app_create_request_one_function,
+    num_concurrent_requests,
 ):
     # Mock the deployment and validation functions
     mocker.patch(
@@ -160,7 +161,7 @@ async def test_concurrent_modal_deployments(
     )
 
     # Create multiple apps concurrently
-    num_apps = 30
+    num_apps: int = num_concurrent_requests
     app_creation_tasks = []
     for i in range(num_apps):
         app_name = f"app-{i}"
@@ -213,6 +214,7 @@ async def test_concurrent_modal_invocations(
     mock_db_session,
     mock_auth_state,
     mock_modal_app_create_request_one_function,
+    num_concurrent_requests,
 ):
     # Mock the deployment and validation functions first
     mocker.patch(
@@ -255,7 +257,7 @@ async def test_concurrent_modal_invocations(
     )
 
     # Create multiple invocations concurrently
-    num_invocations = 30
+    num_invocations: int = num_concurrent_requests
     invocation_tasks = []
     for _ in range(num_invocations):
         task = create_modal_invocation_request(client, function_id)

--- a/garden-backend-service/tests/load_test.py
+++ b/garden-backend-service/tests/load_test.py
@@ -4,6 +4,8 @@ from typing import Any, Dict
 import pytest
 from httpx import AsyncClient
 
+from src.modal.status import AsyncModalJobStatus
+
 
 def create_modal_file_contents(app_name: str, function_name: str) -> str:
     """Create Modal file contents with matching app name and function name"""
@@ -18,6 +20,30 @@ def {function_name}():
 """
 
 
+def create_delayed_deploy_function(delay_seconds: float):
+    """Create a deployment function that simulates a long-running deployment"""
+
+    async def delayed_deploy(deploy_config: Dict[str, Any]):
+        await asyncio.sleep(delay_seconds)
+        return {}  # Mock successful deployment
+
+    return delayed_deploy
+
+
+async def mock_deploy(config: dict[str, str | bytes]) -> None:
+    await asyncio.sleep(2.0)  # Simulate deployment time
+    return None
+
+
+async def mock_validate_modal_file(
+    args: dict[str, str],
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Mock the validate_modal_file function to return hardware specs"""
+    return {
+        "functions": {"predict_iris_type": {"cpu": 0.1, "memory": 256, "gpu": None}}
+    }
+
+
 async def create_modal_app_request(
     client: AsyncClient,
     app_name: str,
@@ -26,11 +52,15 @@ async def create_modal_app_request(
     """Helper function to create a modal app deployment request"""
     # Use the mock request as base and override specific fields
     request_data = mock_modal_app_create_request_one_function.copy()
+    request_data["app_name"] = app_name
+
+    # Get the function name from the request data
     function_name = request_data["modal_functions"][0]["function_name"]
 
-    # Update app name and file contents consistently
-    request_data["app_name"] = app_name
-    request_data["file_contents"] = create_modal_file_contents(app_name, function_name)
+    # Create new file contents with matching app name and function name
+    file_contents = create_modal_file_contents(app_name, function_name)
+    request_data["file_contents"] = file_contents
+
     return await client.post("/modal-apps/async", json=request_data)
 
 
@@ -41,49 +71,87 @@ async def get_modal_app(client: AsyncClient, app_id: int) -> Dict[str, Any]:
     return response.json()
 
 
+async def wait_for_deployment_status(
+    client: AsyncClient,
+    app_id: int,
+    target_status: str,
+    timeout_seconds: float = 10.0,
+    poll_interval_seconds: float = 0.5,
+) -> Dict[str, Any]:
+    """Wait for a modal app to reach the target deployment status"""
+    start_time = asyncio.get_event_loop().time()
+    while True:
+        app = await get_modal_app(client, app_id)
+        if app["deploy_status"] == target_status:
+            return app
+
+        if asyncio.get_event_loop().time() - start_time > timeout_seconds:
+            raise TimeoutError(
+                f"Timed out waiting for app {app_id} to reach status {target_status}. "
+                f"Current status: {app['deploy_status']}"
+            )
+
+        await asyncio.sleep(poll_interval_seconds)
+
+
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_concurrent_modal_deployments(
     client: AsyncClient,
-    mock_db_session,
-    mock_auth_state,
+    monkeypatch,
+    override_publisher_group_membership,
     override_authenticated_dependency,
     override_sandboxed_functions,
-    override_publisher_group_membership,
+    override_get_settings_dependency,
+    mock_db_session,
+    mock_auth_state,
     mock_modal_app_create_request_one_function,
 ):
-    """Test that multiple concurrent modal deployments work correctly"""
-    num_concurrent = 10
-    tasks = []
+    # Mock the deployment and validation functions
+    monkeypatch.setattr(
+        "src.api.dependencies.sandboxed_functions.deploy_modal_app", mock_deploy
+    )
+    monkeypatch.setattr(
+        "src.api.dependencies.sandboxed_functions.validate_modal_file",
+        mock_validate_modal_file,
+    )
 
-    for i in range(num_concurrent):
-        app_name = f"test-app-{i}"
-        tasks.append(
-            create_modal_app_request(
-                client,
-                app_name,
-                mock_modal_app_create_request_one_function,
-            )
+    # Create multiple apps concurrently
+    num_apps = 30
+    app_creation_tasks = []
+    for i in range(num_apps):
+        app_name = f"app-{i}"
+        task = create_modal_app_request(
+            client, app_name, mock_modal_app_create_request_one_function
         )
+        app_creation_tasks.append(task)
 
-    try:
-        responses = await asyncio.gather(*tasks)
-        for i, response in enumerate(responses):
-            print(f"Response {i}: {response.status_code}")
-            assert response.status_code == 200
+    # Wait for all apps to be created
+    responses = await asyncio.gather(*app_creation_tasks)
 
-        # Verify each response has a unique app ID
-        app_ids = [response.json()["id"] for response in responses]
-        assert len(set(app_ids)) == num_concurrent
+    # Verify all creations were successful and get app IDs
+    app_ids = []
+    for response in responses:
+        assert response.status_code == 200
+        app_data = response.json()
+        assert app_data["deploy_status"] == AsyncModalJobStatus.PENDING.value
+        app_ids.append(app_data["id"])
 
-        # Verify app states
-        get_tasks = [get_modal_app(client, app_id) for app_id in app_ids]
-        apps = await asyncio.gather(*get_tasks)
+    # Wait for all deployments to complete concurrently
+    deployment_tasks = []
+    for app_id in app_ids:
+        task = wait_for_deployment_status(
+            client,
+            app_id,
+            AsyncModalJobStatus.DONE.value,
+            timeout_seconds=10.0,  # Longer timeout for concurrent deployments
+        )
+        deployment_tasks.append(task)
 
-        # All apps should be in either pending or done state
-        for app in apps:
-            assert app["deploy_status"] in ["pending", "done"]
+    # Wait for all deployments to finish
+    final_apps = await asyncio.gather(*deployment_tasks)
 
-    except Exception as e:
-        print(f"Error during concurrent requests: {str(e)}")
-        raise
+    # Verify all deployments completed successfully
+    for app in final_apps:
+        assert app["deploy_status"] == AsyncModalJobStatus.DONE.value
+        assert app["deploy_error"] is None

--- a/garden-backend-service/tests/load_test.py
+++ b/garden-backend-service/tests/load_test.py
@@ -1,11 +1,9 @@
 import asyncio
 import base64
 from typing import Any, Dict
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import AsyncClient
-from modal_proto import api_pb2
 
 from src.api.schemas.modal.invocations import ModalInvocationRequest
 from src.modal.status import AsyncModalJobStatus
@@ -52,20 +50,21 @@ async def create_modal_app_request(
     client: AsyncClient,
     app_name: str,
     mock_modal_app_create_request_one_function: Dict[str, Any],
-):
+) -> Dict[str, Any]:
     """Helper function to create a modal app deployment request"""
     # Use the mock request as base and override specific fields
     request_data = mock_modal_app_create_request_one_function.copy()
     request_data["app_name"] = app_name
 
-    # Get the function name from the request data
     function_name = request_data["modal_functions"][0]["function_name"]
 
     # Create new file contents with matching app name and function name
     file_contents = create_modal_file_contents(app_name, function_name)
     request_data["file_contents"] = file_contents
 
-    return await client.post("/modal-apps/async", json=request_data)
+    response = await client.post("/modal-apps/async", json=request_data)
+    assert response.status_code == 200
+    return response.json()
 
 
 async def get_modal_app(client: AsyncClient, app_id: int) -> Dict[str, Any]:
@@ -98,6 +97,21 @@ async def wait_for_deployment_status(
         await asyncio.sleep(poll_interval_seconds)
 
 
+async def create_modal_invocation_request(
+    client: AsyncClient,
+    function_id: int,
+    args_kwargs_serialized: bytes = b"mock_input_data",
+) -> Dict[str, Any]:
+    """Helper function to create a modal invocation request"""
+    request_data = ModalInvocationRequest(
+        function_id=function_id,
+        args_kwargs_serialized=args_kwargs_serialized,
+    ).model_dump()
+    response = await client.post("/modal-invocations/async", json=request_data)
+    assert response.status_code == 200
+    return response.json()
+
+
 async def wait_for_invocation_status(
     client: AsyncClient,
     invocation_id: int,
@@ -124,73 +138,54 @@ async def wait_for_invocation_status(
         await asyncio.sleep(poll_interval_seconds)
 
 
-async def create_modal_invocation_request(
-    client: AsyncClient,
-    function_id: int,
-) -> Any:
-    """Helper function to create a modal invocation request"""
-    request_data = ModalInvocationRequest(
-        function_id=function_id,
-        args_kwargs_serialized=b"mock_input_data",
-    ).model_dump()
-    return await client.post("/modal-invocations/async", json=request_data)
-
-
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_concurrent_modal_deployments(
-    client: AsyncClient,
-    mocker,
-    override_publisher_group_membership,
-    override_authenticated_dependency,
-    override_sandboxed_functions,
-    override_get_settings_dependency,
-    mock_db_session,
-    mock_auth_state,
-    mock_modal_app_create_request_one_function,
-    num_concurrent_requests,
+    modal_deployment_environment: dict[str, Any],
+    num_concurrent_requests: int,
 ):
+    """Test that multiple Modal apps can be deployed concurrently"""
+    env = modal_deployment_environment
+    client = env["client"]
+    mocker = env["mocker"]
+
     # Mock the deployment and validation functions
     mocker.patch(
         "src.api.dependencies.sandboxed_functions.deploy_modal_app",
-        side_effect=mock_deploy,
+        side_effect=lambda config: asyncio.sleep(2.0),  # Simulate deployment time
     )
     mocker.patch(
         "src.api.dependencies.sandboxed_functions.validate_modal_file",
-        side_effect=mock_validate_modal_file,
+        return_value={
+            "functions": {"predict_iris_type": {"cpu": 0.1, "memory": 256, "gpu": None}}
+        },
     )
 
     # Create multiple apps concurrently
-    num_apps: int = num_concurrent_requests
-    app_creation_tasks = []
-    for i in range(num_apps):
-        app_name = f"app-{i}"
-        task = create_modal_app_request(
-            client, app_name, mock_modal_app_create_request_one_function
-        )
-        app_creation_tasks.append(task)
+    app_creation_tasks = [
+        create_modal_app_request(client, f"app-{i}", env["app_request"])
+        for i in range(num_concurrent_requests)
+    ]
 
     # Wait for all apps to be created
-    responses = await asyncio.gather(*app_creation_tasks)
+    created_apps = await asyncio.gather(*app_creation_tasks)
 
     # Verify all creations were successful and get app IDs
     app_ids = []
-    for response in responses:
-        assert response.status_code == 200
-        app_data = response.json()
+    for app_data in created_apps:
         assert app_data["deploy_status"] == AsyncModalJobStatus.PENDING.value
         app_ids.append(app_data["id"])
 
     # Wait for all deployments to complete concurrently
-    deployment_tasks = []
-    for app_id in app_ids:
-        task = wait_for_deployment_status(
+    deployment_tasks = [
+        wait_for_deployment_status(
             client,
             app_id,
             AsyncModalJobStatus.DONE.value,
-            timeout_seconds=10.0,  # Longer timeout for concurrent deployments
+            timeout_seconds=10.0,
         )
-        deployment_tasks.append(task)
+        for app_id in app_ids
+    ]
 
     # Wait for all deployments to finish
     final_apps = await asyncio.gather(*deployment_tasks)
@@ -204,86 +199,52 @@ async def test_concurrent_modal_deployments(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_concurrent_modal_invocations(
-    client: AsyncClient,
-    mocker,
-    override_publisher_group_membership,
-    override_authenticated_dependency,
-    override_sandboxed_functions,
-    override_get_settings_dependency,
-    override_get_modal_client_dependency,
-    mock_db_session,
-    mock_auth_state,
-    mock_modal_app_create_request_one_function,
-    num_concurrent_requests,
+    modal_deployment_environment: dict[str, Any],
+    num_concurrent_requests: int,
 ):
-    # Mock the deployment and validation functions first
-    mocker.patch(
-        "src.api.dependencies.sandboxed_functions.deploy_modal_app",
-        side_effect=mock_deploy,
-    )
-    mocker.patch(
-        "src.api.dependencies.sandboxed_functions.validate_modal_file",
-        side_effect=mock_validate_modal_file,
-    )
+    """Test that multiple Modal functions can be invoked concurrently"""
+    env = modal_deployment_environment
+    client = env["client"]
+    mocker = env["mocker"]
 
     # Create a modal app with a function to invoke
-    response = await client.post(
-        "/modal-apps", json=mock_modal_app_create_request_one_function
-    )
+    response = await client.post("/modal-apps", json=env["app_request"])
     assert response.status_code == 200
     response_data = response.json()
     function_id = response_data["modal_function_ids"][0]
 
-    # Mock the modal function lookup and invocation creation
-    mock_invocation = AsyncMock()
-    mock_invocation.function_call_id = "mock_call_id"
-    # Mock the pop_function_call_outputs to simulate a successful invocation
-    mock_outputs_response = MagicMock()
-    output_item = api_pb2.FunctionGetOutputsItem(
-        result=api_pb2.GenericResult(
-            status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS, data=b"mock_result"
-        ),
-        data_format=api_pb2.DATA_FORMAT_PICKLE,
-    )
-    mock_outputs_response.outputs = [output_item]
-    mock_invocation.pop_function_call_outputs.return_value = mock_outputs_response
-
-    mock_function = MagicMock()
-    mock_function._invocation_function_id.return_value = "mock_function_id"
-    mocker.patch("modal.functions._Function.lookup", return_value=mock_function)
+    # Mock the modal function lookup and invocation
+    mocker.patch("modal.functions._Function.lookup", return_value=env["mock_function"])
     mocker.patch(
         "src.api.routes.modal.invocations._create_invocation",
-        return_value=mock_invocation,
+        return_value=env["mock_invocation"],
     )
 
     # Create multiple invocations concurrently
-    num_invocations: int = num_concurrent_requests
-    invocation_tasks = []
-    for _ in range(num_invocations):
-        task = create_modal_invocation_request(client, function_id)
-        invocation_tasks.append(task)
+    invocation_tasks = [
+        create_modal_invocation_request(client, function_id)
+        for _ in range(num_concurrent_requests)
+    ]
 
     # Wait for all invocations to be created
-    responses = await asyncio.gather(*invocation_tasks)
+    created_invocations = await asyncio.gather(*invocation_tasks)
 
     # Verify all creations were successful and get invocation IDs
     invocation_ids = []
-    for response in responses:
-        assert response.status_code == 200
-        invocation_data = response.json()
+    for invocation_data in created_invocations:
         assert invocation_data["status"] == AsyncModalJobStatus.PENDING.value
         invocation_ids.append(invocation_data["id"])
 
     # Wait for all invocations to complete concurrently
-    completion_tasks = []
-    for invocation_id in invocation_ids:
-        task = wait_for_invocation_status(
+    completion_tasks = [
+        wait_for_invocation_status(
             client,
             invocation_id,
             AsyncModalJobStatus.DONE.value,
-            timeout_seconds=10.0,  # Longer timeout for concurrent invocations
+            timeout_seconds=10.0,
         )
-        completion_tasks.append(task)
+        for invocation_id in invocation_ids
+    ]
 
     # Wait for all invocations to finish
     final_invocations = await asyncio.gather(*completion_tasks)


### PR DESCRIPTION
Resolves: #229 

## Overview

This PR adds load tests of the async modal publishing, and async invocation flows.


Included are fixes with our async setup that I discovered along the way including:

- a race condition when getting concurrent requests with a new user that caused db integrity errors
    - fixed by handling user creation logic in the authed_user dependency
- an issue in the async POST route with how we were passing the `db_modal_app` to the background task that tied it to the db session of the request.
    - fixed by passing the id of the new modal app to the background task and having the background task query for the model using a new session

## Discussion

We hit an error when sending >~30 concurrent deployment requests that comes from asyncpg hitting its connection pool limit. Setting the engine pool size parameter to a higher value , e.g. `create_async_engine(..., pool_size=50)`, doesn't seem to have any effect on the number of concurrent requests we can serve with our current setup. I will keep thinking about this, but we can service a decent amount of requests right now so we can kick the can down the road a bit here.

## Testing
I added a CLI arg for pytest `--num-concurrent-requests` (defaults to 30) so we have any easy way of testing different sized loads.

```shell
uv run pytest --num-concurrent-requests 50 tests/load_test.py
```

The number of concurrent requests is configurable via an environment variable `GARDEN_TEST_NUM_CONCURRENT_REQUESTS`:

```shell
GARDEN_TEST_NUM_CONCURRENT_REQUESTS=50 uv run pytest tests/load_test.py
```

Pytest prioritizes the cli arg, for example:

```shell
# will run with 5 concurrent requests
GARDEN_TEST_NUM_CONCURRENT_REQUESTS=50 uv run pytest --num-concurrent-requests 5 tests/load_test.py
```
