### PR TITLE
Fix logging issue caused by startlette middleware base class

### DIFF
--- a/garden-backend-service/src/main.py
+++ b/garden-backend-service/src/main.py
@@ -22,9 +22,9 @@ from src.api.routes import (
 from src.api.routes.mdf import search as mdf_search
 from src.config import Settings, get_settings
 from src.middleware.logging import (
-    ErrorHandlingMiddleware,
-    # LogProcessTimeMiddleware,
-    # LogRequestIdMiddleware,
+    add_error_handling_middleware,
+    add_process_time_middleware,
+    add_request_id_middleware,
 )
 
 
@@ -57,12 +57,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(ErrorHandlingMiddleware)
-# As currently written (subclassing BaseHTTPMiddleware), these middlewares interfere with background tasks
-# See https://github.com/encode/starlette/issues/919 for more details
-# TODO: Find a way to work around this and bring these log statements back
-# app.add_middleware(LogProcessTimeMiddleware)
-# app.add_middleware(LogRequestIdMiddleware)
+
+# Add our custom middleware
+add_error_handling_middleware(app)
+add_process_time_middleware(app)
+add_request_id_middleware(app)
 
 app.include_router(greet.router)
 app.include_router(doi.router)

--- a/garden-backend-service/src/middleware/logging.py
+++ b/garden-backend-service/src/middleware/logging.py
@@ -1,20 +1,18 @@
 import time
 import uuid
+from typing import Callable
 
 import structlog
-from fastapi import Request, Response
+from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from src.exceptions.modal import ModalException, handle_modal_exception
 from src.exceptions.utils import format_traceback
 
 
-class LogRequestIdMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app):
-        super().__init__(app)
-
-    async def dispatch(self, request: Request, call_next):
+def add_request_id_middleware(app: FastAPI) -> None:
+    @app.middleware("http")
+    async def request_id_middleware(request: Request, call_next: Callable) -> Response:
         request_id = str(uuid.uuid4())
         request.state.request_id = request_id
 
@@ -28,14 +26,14 @@ class LogRequestIdMiddleware(BaseHTTPMiddleware):
         return response
 
 
-class LogProcessTimeMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app):
-        super().__init__(app)
-
-    async def dispatch(self, request: Request, call_next):
+def add_process_time_middleware(app: FastAPI) -> None:
+    @app.middleware("http")
+    async def process_time_middleware(
+        request: Request, call_next: Callable
+    ) -> Response:
         start_time = time.time()
 
-        response: Response = await call_next(request)
+        response = await call_next(request)
 
         process_time = (time.time() - start_time) * 1000
         formatted_process_time = f"{process_time:.2f}"
@@ -55,11 +53,11 @@ class LogProcessTimeMiddleware(BaseHTTPMiddleware):
         return response
 
 
-class ErrorHandlingMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app):
-        super().__init__(app)
-
-    async def dispatch(self, request: Request, call_next):
+def add_error_handling_middleware(app: FastAPI) -> None:
+    @app.middleware("http")
+    async def error_handling_middleware(
+        request: Request, call_next: Callable
+    ) -> Response:
         try:
             return await call_next(request)
         except ModalException as e:


### PR DESCRIPTION
Resolves: #228

## Overview

This PR fixes the issue we were having with background tasks and the starlette middle ware base classes.

Using this approach: https://fastapi.tiangolo.com/tutorial/middleware/ appears to get around the issue with little fuss.

## Testing

Tested manually by deploying a modal app with function that sleeps for 10 seconds, invoked the function via the SDK, and watched the logs. The logs showed a response immediately after the request was initiated, as well as the logs for the repeated GET requests polling the invocation status before returning the result.
