### PR TITLE
fix: file validation image variable references

### DIFF
--- a/garden-backend-service/src/modal/user_file_parsing.py
+++ b/garden-backend-service/src/modal/user_file_parsing.py
@@ -48,7 +48,7 @@ class ModalImageInfo:
 def _image_default() -> ModalImageInfo:
     # helper for use with default_factory below
     call_node = ast.parse("modal.Image.debian_slim()").body[0].value
-    return try_parse_image_info(call_node)
+    return try_parse_image_info(call_node, parsed_images={})
 
 
 @dataclass
@@ -107,7 +107,7 @@ def parse_modal_file(contents: str) -> ModalFileParseResults:
             # Case 1: assigning a Modal image to a variable
             case ast.Assign(
                 targets=[ast.Name(id=image_name)], value=ast.Call() as call_node
-            ) if image_info := try_parse_image_info(call_node):
+            ) if image_info := try_parse_image_info(call_node, images):
                 images[image_name] = image_info
 
             # Case 2: assigning a Modal app to a variable
@@ -151,7 +151,11 @@ def parse_modal_file(contents: str) -> ModalFileParseResults:
 
 
 # image info helpers
-def try_parse_image_info(node: ast.Call, _info=None) -> ModalImageInfo | None:
+def try_parse_image_info(
+    node: ast.Call,
+    parsed_images: dict[str, ModalImageInfo],
+    _info=None,
+) -> ModalImageInfo | None:
     """Return a ModalImageInfo object if the given Call node constructs a modal Image, otherwise return None."""
     info = _info or ModalImageInfo()
 
@@ -167,10 +171,17 @@ def try_parse_image_info(node: ast.Call, _info=None) -> ModalImageInfo | None:
             )
         ):
             return _update_image_info_from_root_staticmethod(node, info)
+        # base case 2: method chained on an existing image variable, like `my_img = my_base_image.<factory_method>`
+        case ast.Attribute(value=ast.Name(id=image_var)) if image_var in parsed_images:
+            base_info = parsed_images[image_var]
+            new_info = _update_image_info_from_factory_method(node, base_info)
+            new_info.pip_requirements.extend(info.pip_requirements)
+            new_info.conda_requirements.extend(info.conda_requirements)
+            return new_info
         # recursive case: chained method, the value of the attribute node is another call node
         case ast.Attribute(value=ast.Call() as next_node):
             info = _update_image_info_from_factory_method(node, info)
-            return try_parse_image_info(next_node, info)
+            return try_parse_image_info(next_node, parsed_images, info)
         # otherwise, this call node doesn't construct a valid modal image
         case _:
             return None
@@ -311,7 +322,7 @@ def _update_app_info_from_constructor(
                     app_info.image = image_info
                 elif kw.arg == "image" and isinstance(kw.value, ast.Call):
                     # handle case where kwarg is `image=modal.Image.<chained_image_methods>`
-                    image_info = try_parse_image_info(kw.value)
+                    image_info = try_parse_image_info(kw.value, parsed_images)
                     app_info.image = image_info
 
                 # TODO disallow other kwargs? (volumes, etc)
@@ -361,6 +372,7 @@ def _update_function_info_from_decorator(
     parsed_images: dict[str, ModalImageInfo] | None = None,
     parsed_apps: dict[str, ModalAppInfo] | None = None,
 ) -> ModalFunctionInfo:
+    parsed_images = parsed_images or {}
     func_info = copy.deepcopy(info)
     for kw in node.keywords:
         match kw:
@@ -371,8 +383,11 @@ def _update_function_info_from_decorator(
                 func_info.image = image_info
             case ast.keyword(arg="image", value=ast.Call()):
                 # handle case where kwarg is `image=modal.Image.<chained_image_methods>`
-                image_info = try_parse_image_info(kw.value)
-                func_info.image = image_info
+                image_info = try_parse_image_info(kw.value, parsed_images)
+                if image_info is None:
+                    func_info.image = _image_default()  # default is sane if this fails, no need to error and stop the publish attempt
+                else:
+                    func_info.image = image_info
             case ast.keyword(arg="name", value=ast.Constant(value=str(new_name))):
                 func_info.function_name = new_name
             case ast.keyword(arg=arg) if arg in FUNCTION_KWARG_BLOCKLIST:
@@ -417,7 +432,7 @@ def try_parse_class_function_info(
                         image_name = kw.value.id
                         class_image = parsed_images.get(image_name) or class_image
                     case ast.keyword(arg="image", value=ast.Call()):
-                        class_image = try_parse_image_info(kw.value)
+                        class_image = try_parse_image_info(kw.value, parsed_images)
 
             # Collect all methods decorated with @modal.method()
             for method in node.body:

--- a/garden-backend-service/tests/api/routes/modal/test_modal_file_metadata.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_file_metadata.py
@@ -10,6 +10,7 @@ from tests.fixtures.modal_file_constants import (
     VALID_BASIC_IMPORTS,
     VALID_CLASS_BASED,
     VALID_CONDA_PACKAGES,
+    VALID_MULTIPLE_IMAGE_VARIABLE_REFERENCES,
     VALID_MULTIPLE_IMAGES,
     VALID_MULTIPLE_LOCAL_ENTRYPOINTS,
     VALID_NO_CUSTOM_IMAGE,
@@ -107,6 +108,33 @@ async def test_validate_multiple_images(client, _metadata_validation_fixtures):
             assert set(fn_info["requirements"]) == {"numpy", "scipy"}
         elif fn_info["function_name"] == "ml_stuff":
             assert set(fn_info["requirements"]) == {"torch", "transformers"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_validate_multiple_image_variables(client, _metadata_validation_fixtures):
+    response = await client.post(
+        "/modal-file-metadata",
+        json={"file_contents": VALID_MULTIPLE_IMAGE_VARIABLE_REFERENCES},
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    _assert_response_metadata(
+        data, "multi-image-app", expected_function_names=["science_stuff", "ml_stuff"]
+    )
+
+    for fn_info in data["modal_functions"]:
+        if fn_info["function_name"] == "science_stuff":
+            assert set(fn_info["requirements"]) == {"numpy", "scipy"}
+        elif fn_info["function_name"] == "ml_stuff":
+            # should have requirements from both images
+            assert set(fn_info["requirements"]) == {
+                "numpy",
+                "scipy",
+                "torch",
+                "transformers",
+            }
 
 
 @pytest.mark.asyncio

--- a/garden-backend-service/tests/fixtures/modal_file_constants.py
+++ b/garden-backend-service/tests/fixtures/modal_file_constants.py
@@ -204,3 +204,32 @@ def secure_function():
     import os
     return os.environ["MY_SECRET"]
 """
+
+VALID_MULTIPLE_IMAGE_VARIABLE_REFERENCES = """ 
+import modal
+
+# Base scientific image
+SCI_IMAGE = modal.Image.debian_slim().pip_install(
+    "numpy",
+    "scipy"
+)
+
+# Image for deep learning
+ML_IMAGE = SCI_IMAGE.pip_install(
+    "torch",
+    "transformers"
+)
+
+app = modal.App("multi-image-app")
+
+@app.function(image=SCI_IMAGE)
+def science_stuff():
+    import numpy as np
+    return np.random.rand(10)
+
+@app.function(image=ML_IMAGE, gpu="A100")
+def ml_stuff():
+    import torch
+    return torch.rand(10)
+
+"""


### PR DESCRIPTION
fixes #238 

## Overview
Quick QOL fix for an error I ran into making image variants for the full MACE garden. The edge case this fixes is probably more likely in a post-`@modal.build`-deprecation world than it was previously. 

## Discussion 

This was a pretty small change to the file validation module -- in addition to handling the extra base case, failing to parse a base image for a function now gives it the default image instead of erroring. I think this is reasonable since the image metadata is something we want to collect but which we aren't displaying to the user for review during the publication process.  

## Testing

No tests (yet) besides manual testing by publishing a garden locally 