### PR TITLE
Add example usage to common function patch request schema

### DIFF
--- a/garden-backend-service/src/api/schemas/shared_function_schemas.py
+++ b/garden-backend-service/src/api/schemas/shared_function_schemas.py
@@ -59,6 +59,7 @@ class CommonFunctionPatchRequest(BaseSchema):
     year: str | None = None
 
     function_text: str | None = None
+    example_usage: str | None = None
 
     authors: UniqueList[str] | None = None
     tags: UniqueList[str] | None = None


### PR DESCRIPTION
This PR adds the `example_usage` field to the common function patch request schema. This facilitates updates to existing modal functions on the frontend.

Related frontend PR: https://github.com/Garden-AI/garden-frontend/pull/260
