### PR TITLE
extract arxiv metadata from link 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ response.json
 /garden-backend-service/repopack-output.txt
 /garden-backend-service/.basedpyright
 /garden-backend-service/.envrc
+.envrc

--- a/garden-backend-service/pyproject.toml
+++ b/garden-backend-service/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
   "phonenumbers>=8.13.40",
   "structlog>=24.4.0",
   "sqlparse>=0.5.1",
-  "modal>=0.66.37,<0.67.0",      # NOTE: remember to bump modal dep in sandboxed lambda functions when this changes
+  "modal>=0.66.37,<0.67.0", # NOTE: remember to bump modal dep in sandboxed lambda functions when this changes
+  "arxiv>=2.1.3",
 ]
 
 [dependency-groups]

--- a/garden-backend-service/src/api/routes/metadata/__init__.py
+++ b/garden-backend-service/src/api/routes/metadata/__init__.py
@@ -1,0 +1,3 @@
+import src.api.routes.metadata.arxiv_papers as arxiv_papers
+
+__all__ = [arxiv_papers]

--- a/garden-backend-service/src/api/routes/metadata/arxiv.py
+++ b/garden-backend-service/src/api/routes/metadata/arxiv.py
@@ -1,0 +1,40 @@
+import arxiv
+from fastapi import APIRouter, HTTPException, status
+from structlog import get_logger
+
+from src.api.schemas.papers import LinkArxivMetadataRequest, LinkArxivMetadataResponse
+
+logger = get_logger(__name__)
+router = APIRouter(prefix="/arxiv-paper-metadata")
+
+
+@router.post("")
+def extract_arxiv_paper_metadata(
+    request: LinkArxivMetadataRequest,
+) -> LinkArxivMetadataResponse:
+    # Use the arxiv package to fetch paper metadata
+    try:
+        client = arxiv.Client()
+        search = arxiv.Search(id_list=[request.arxiv_identifier], max_results=1)
+        results = list(client.results(search))
+    except Exception as e:
+        logger.exception(f"Error fetching arXiv metadata: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch arXiv metadata. Please try again later.",
+        ) from e
+    if not results:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No arXiv paper found with identifier: {request.arxiv_identifier}",
+        )
+    paper = results[0]
+
+    return LinkArxivMetadataResponse(
+        title=paper.title,
+        authors=[author.name for author in paper.authors],
+        doi=paper.doi or None,
+        url=request.url,
+        description=paper.summary.replace("\n", " ").strip(),
+        citation=paper.journal_ref or None,
+    )

--- a/garden-backend-service/src/api/routes/metadata/arxiv_papers.py
+++ b/garden-backend-service/src/api/routes/metadata/arxiv_papers.py
@@ -12,7 +12,6 @@ router = APIRouter(prefix="/arxiv-paper-metadata")
 def extract_arxiv_paper_metadata(
     request: LinkArxivMetadataRequest,
 ) -> LinkArxivMetadataResponse:
-    # Use the arxiv package to fetch paper metadata
     try:
         client = arxiv.Client()
         search = arxiv.Search(id_list=[request.arxiv_identifier], max_results=1)

--- a/garden-backend-service/src/api/routes/modal/__init__.py
+++ b/garden-backend-service/src/api/routes/modal/__init__.py
@@ -1,4 +1,7 @@
-import src.api.routes.modal.invocations  # noqa
-import src.api.routes.modal.modal_apps  # noqa
-import src.api.routes.modal.modal_functions  # noqa
-import src.api.routes.modal.modal_file_metadata  # noqa
+import src.api.routes.modal.invocations as invocations  # noqa
+import src.api.routes.modal.modal_apps as modal_apps  # noqa
+import src.api.routes.modal.modal_functions as modal_functions  # noqa
+import src.api.routes.modal.modal_file_metadata as modal_file_metadata  # noqa
+
+
+__all__ = [invocations, modal_apps, modal_functions, modal_file_metadata]

--- a/garden-backend-service/src/api/schemas/base.py
+++ b/garden-backend-service/src/api/schemas/base.py
@@ -34,6 +34,16 @@ class BaseSchema(BaseModel, from_attributes=True):
         return val
 
 
+class BaseRelatedMetadataSchema(BaseSchema, extra="allow"):
+    """Base class for "related metadata" types like papers, repositories etc.
+
+    For these types we typically want to allow (rather than ignore) extra
+    metadata fields when we store/retrieve the raw json in the DB.
+    """
+
+    ...
+
+
 T = TypeVar("T")
 
 

--- a/garden-backend-service/src/api/schemas/papers.py
+++ b/garden-backend-service/src/api/schemas/papers.py
@@ -1,0 +1,37 @@
+from typing import Annotated
+
+from pydantic import AfterValidator, computed_field
+
+from .base import BaseSchema, Url
+from .shared_function_schemas import _PaperMetadata
+
+
+def _is_arxiv_url(url: Url) -> Url:
+    assert "arxiv.org" in str(url).lower(), "must be an arxiv url"
+    return url
+
+
+ArxivUrl = Annotated[Url, AfterValidator(_is_arxiv_url)]
+
+
+class LinkArxivMetadataRequest(BaseSchema):
+    url: ArxivUrl
+
+    @computed_field
+    @property
+    def arxiv_identifier(self) -> str:
+        url = str(self.url).strip()
+        if "/pdf/" in url:
+            # if the link looks like http://arxiv.org/pdf/{identifier}.pdf
+            suffix = url.split("/pdf/")[-1]
+            return suffix.split(".pdf")[0]
+        elif "/abs/" in url:
+            # otherwise url links to regular abstract page, not pdf
+            return url.split("/abs/")[-1]
+        else:
+            raise ValueError(f"Failed to parse arXiv identifier from url {url}")
+
+
+class LinkArxivMetadataResponse(_PaperMetadata):
+    # makes url mandatory for arxiv papers
+    url: ArxivUrl  # type: ignore

--- a/garden-backend-service/src/api/schemas/shared_function_schemas.py
+++ b/garden-backend-service/src/api/schemas/shared_function_schemas.py
@@ -1,22 +1,24 @@
 from pydantic import Field
 
-from .base import BaseSchema, UniqueList, Url
+from .base import BaseRelatedMetadataSchema, BaseSchema, UniqueList, Url
 
 
-class _RepositoryMetadata(BaseSchema):
+class _RepositoryMetadata(BaseRelatedMetadataSchema):
     repo_name: str
     url: Url
     contributors: UniqueList[str] = Field(default_factory=list)
 
 
-class _PaperMetadata(BaseSchema):
-    title: str
+class _PaperMetadata(BaseRelatedMetadataSchema):
+    title: str | None = None
     authors: UniqueList[str] = Field(default_factory=list)
-    doi: str | None
-    citation: str | None
+    doi: str | None = None
+    description: str | None = None
+    citation: str | None = None
+    url: Url | None = None
 
 
-class _DatasetMetadata(BaseSchema):
+class _DatasetMetadata(BaseRelatedMetadataSchema):
     title: str = Field(...)
     doi: str | None
     url: Url
@@ -25,7 +27,7 @@ class _DatasetMetadata(BaseSchema):
 
 
 # protected_namespaces=() to allow model_* attribute names
-class _ModelMetadata(BaseSchema, protected_namespaces=()):
+class _ModelMetadata(BaseRelatedMetadataSchema, protected_namespaces=()):
     model_identifier: str
     model_repository: str
     model_version: str | None

--- a/garden-backend-service/src/main.py
+++ b/garden-backend-service/src/main.py
@@ -17,6 +17,7 @@ from src.api.routes import (
     greet,
     hello_database,
     load_test,
+    metadata,
     modal,
     notebook,
     users,
@@ -74,6 +75,8 @@ app.include_router(modal.invocations.router)
 app.include_router(modal.modal_apps.router)
 app.include_router(modal.modal_functions.router)
 app.include_router(modal.modal_file_metadata.router)
+
+app.include_router(metadata.arxiv_papers.router)
 
 app.include_router(mdf_search.router)
 

--- a/garden-backend-service/tests/api/routes/metadata/test_arxiv_papers.py
+++ b/garden-backend-service/tests/api/routes/metadata/test_arxiv_papers.py
@@ -1,0 +1,15 @@
+import pytest
+
+from src.api.schemas.papers import LinkArxivMetadataRequest
+
+
+@pytest.mark.asyncio
+async def test_extract_arxiv_identifier_abs_format():
+    request = LinkArxivMetadataRequest(url="https://arxiv.org/abs/2301.04589")
+    assert request.arxiv_identifier == "2301.04589"
+
+
+@pytest.mark.asyncio
+async def test_extract_arxiv_identifier_pdf_format():
+    request = LinkArxivMetadataRequest(url="https://arxiv.org/pdf/2301.04589.pdf")
+    assert request.arxiv_identifier == "2301.04589"

--- a/garden-backend-service/tests/fixtures/EntrypointCreateRequest-with-metadata.json
+++ b/garden-backend-service/tests/fixtures/EntrypointCreateRequest-with-metadata.json
@@ -1,52 +1,63 @@
 {
-    "doi": "10.26311/entrypoint-with-related-metadata",
-    "title": "Oxide vacancy formation energy model",
-    "authors": ["Ryan Jacobs"],
-    "short_name": "predict_oxide_vacancy",
-    "description": "Random forest model to predict the formation energy of O vacancies in oxides",
-    "year": "2024",
-    "tags": ["scikit-learn", "mastml"],
-    "is_archived": false,
-    "models": [
-        {
-            "model_identifier": "rjacobs3/model_oxide_vacancy",
-            "model_repository": "Hugging Face",
-            "model_version": "main"
-        }
-    ],
-    "repositories": [
-        {
-            "repo_name": "uw-cmg/MAST-ML",
-            "url": "https://github.com/uw-cmg/MAST-ML",
-            "contributors": ["rjacobs914"]
-        }
-    ],
-    "papers": [
-        {
-            "title": "Machine Learning Materials Properties with Accurate Predictions, Uncertainty Estimates, Domain Guidance, and Persistent Online Accessibility",
-            "authors": ["Ryan Jacobs"],
-            "doi": "10.1234/fake-paper-doi",
-            "citation": ""
-        }
-    ],
-    "datasets": [
-        {
-            "title": "Benchmark Dataset for Locating Atoms in STEM images",
-            "doi": "10.18126/e73h-3w6n",
-            "url": "https://foundry-ml.org/#/datasets/10.18126%2Fe73h-3w6n",
-            "data_type": "csv",
-            "repository": "foundry"
-        }
-    ],
-    "doi_is_draft": true,
-    "func_uuid": "daa1a8f5-30ea-4f14-80d1-318fea994101",
-    "container_uuid": "9cb2ae42-8b9d-4a68-8d91-0bf49181ac70",
-    "base_image_uri": "gardenai/base:python-3.11-wisconsin",
-    "full_image_uri": "public.ecr.aws/x2v7f8j4/garden-containers-prod:pushed-20240402-171837695950",
-    "notebook_url": "https://pipeline-notebooks-prod.s3.amazonaws.com/RJACOBS3@WISC.EDU/oxide_vacancy_notebook.ipynb-59980c4e38a2d2a536c2f8d4ab778d757c7af8529b0e8c58e6b2d8cc13f26809.ipynb",
-    "test_functions": [
-        "@entrypoint_test(predict_oxide_vacancy)\ndef test_the_model():\n    comps_list = ['Ac2O3', 'AcAgO3', 'AcAlO3']\n    result = predict_oxide_vacancy(comps_list)\n    return result\n"
-    ],
-    "requirements": [],
-    "function_text": "@garden_entrypoint(\n    metadata=model_entrypoint_meta,  \n    model_connectors=[github_connector], \n    garden_doi=my_garden_doi\n)\ndef predict_oxide_vacancy(comp_list):\n    import shutil, zipfile\n    import os\n    import sys\n    import warnings\n    warnings.filterwarnings(\"ignore\")\n    \n    if not os.path.exists('model_oxide_vacancy'):\n        download_path = github_connector.stage()\n        shutil.move('hf_model', 'model_oxide_vacancy')\n\n    sys.path.append('model_oxide_vacancy')\n\n    from predict_oxide_vacancy import make_predictions\n    \n    preds = make_predictions(comp_list)\n\n    return preds\n"
+  "doi": "10.26311/entrypoint-with-related-metadata",
+  "title": "Oxide vacancy formation energy model",
+  "authors": [
+    "Ryan Jacobs"
+  ],
+  "short_name": "predict_oxide_vacancy",
+  "description": "Random forest model to predict the formation energy of O vacancies in oxides",
+  "year": "2024",
+  "tags": [
+    "scikit-learn",
+    "mastml"
+  ],
+  "is_archived": false,
+  "models": [
+    {
+      "model_identifier": "rjacobs3/model_oxide_vacancy",
+      "model_repository": "Hugging Face",
+      "model_version": "main"
+    }
+  ],
+  "repositories": [
+    {
+      "repo_name": "uw-cmg/MAST-ML",
+      "url": "https://github.com/uw-cmg/MAST-ML",
+      "contributors": [
+        "rjacobs914"
+      ]
+    }
+  ],
+  "papers": [
+    {
+      "title": "Machine Learning Materials Properties with Accurate Predictions, Uncertainty Estimates, Domain Guidance, and Persistent Online Accessibility",
+      "authors": [
+        "Ryan Jacobs"
+      ],
+      "doi": "10.1234/fake-paper-doi",
+      "citation": "",
+      "url": null,
+      "description": null
+    }
+  ],
+  "datasets": [
+    {
+      "title": "Benchmark Dataset for Locating Atoms in STEM images",
+      "doi": "10.18126/e73h-3w6n",
+      "url": "https://foundry-ml.org/#/datasets/10.18126%2Fe73h-3w6n",
+      "data_type": "csv",
+      "repository": "foundry"
+    }
+  ],
+  "doi_is_draft": true,
+  "func_uuid": "daa1a8f5-30ea-4f14-80d1-318fea994101",
+  "container_uuid": "9cb2ae42-8b9d-4a68-8d91-0bf49181ac70",
+  "base_image_uri": "gardenai/base:python-3.11-wisconsin",
+  "full_image_uri": "public.ecr.aws/x2v7f8j4/garden-containers-prod:pushed-20240402-171837695950",
+  "notebook_url": "https://pipeline-notebooks-prod.s3.amazonaws.com/RJACOBS3@WISC.EDU/oxide_vacancy_notebook.ipynb-59980c4e38a2d2a536c2f8d4ab778d757c7af8529b0e8c58e6b2d8cc13f26809.ipynb",
+  "test_functions": [
+    "@entrypoint_test(predict_oxide_vacancy)\ndef test_the_model():\n    comps_list = ['Ac2O3', 'AcAgO3', 'AcAlO3']\n    result = predict_oxide_vacancy(comps_list)\n    return result\n"
+  ],
+  "requirements": [],
+  "function_text": "@garden_entrypoint(\n    metadata=model_entrypoint_meta,  \n    model_connectors=[github_connector], \n    garden_doi=my_garden_doi\n)\ndef predict_oxide_vacancy(comp_list):\n    import shutil, zipfile\n    import os\n    import sys\n    import warnings\n    warnings.filterwarnings(\"ignore\")\n    \n    if not os.path.exists('model_oxide_vacancy'):\n        download_path = github_connector.stage()\n        shutil.move('hf_model', 'model_oxide_vacancy')\n\n    sys.path.append('model_oxide_vacancy')\n\n    from predict_oxide_vacancy import make_predictions\n    \n    preds = make_predictions(comp_list)\n\n    return preds\n"
 }

--- a/garden-backend-service/uv.lock
+++ b/garden-backend-service/uv.lock
@@ -214,6 +214,19 @@ wheels = [
 ]
 
 [[package]]
+name = "arxiv"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "feedparser" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/59/fe41f54bdfed776c2e9bcd6289e4c71349eb938241d89b4c97d0f33e8013/arxiv-2.1.3.tar.gz", hash = "sha256:32365221994d2cf05657c1fadf63a26efc8ccdec18590281ee03515bfef8bc4e", size = 16747 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/7b/7bf42178d227b26d3daf94cdd22a72a4ed5bf235548c4f5aea49c51c6458/arxiv-2.1.3-py3-none-any.whl", hash = "sha256:6f43673ab770a9e848d7d4fc1894824df55edeac3c3572ea280c9ba2e3c0f39f", size = 11478 },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -608,6 +621,18 @@ wheels = [
 ]
 
 [[package]]
+name = "feedparser"
+version = "6.0.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sgmllib3k" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/aa/7af346ebeb42a76bf108027fe7f3328bb4e57a3a96e53e21fd9ef9dd6dd0/feedparser-6.0.11.tar.gz", hash = "sha256:c9d0407b64c6f2a065d0ebb292c2b35c01050cc0dc33757461aaabdc4c4184d5", size = 286197 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/d4/8c31aad9cc18f451c49f7f9cfb5799dadffc88177f7917bc90a66459b1d7/feedparser-6.0.11-py3-none-any.whl", hash = "sha256:0be7ee7b395572b19ebeb1d6aafb0028dee11169f1c934e0ed67d54992f4ad45", size = 81343 },
+]
+
+[[package]]
 name = "filelock"
 version = "3.12.4"
 source = { registry = "https://pypi.org/simple" }
@@ -677,6 +702,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "aioboto3" },
     { name = "alembic" },
+    { name = "arxiv" },
     { name = "asyncpg" },
     { name = "boto3" },
     { name = "cachetools" },
@@ -723,6 +749,7 @@ develop = [
 requires-dist = [
     { name = "aioboto3", specifier = ">=13.3.0" },
     { name = "alembic", specifier = ">=1.13.1" },
+    { name = "arxiv", specifier = ">=2.1.3" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "boto3", specifier = ">=1.34.84" },
     { name = "cachetools", specifier = ">=5.3.3" },
@@ -2224,6 +2251,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/92/ec/089608b791d210aec
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/8a/b9dc7678803429e4a3bc9ba462fa3dd9066824d3c607490235c6a796be5a/setuptools-75.8.0-py3-none-any.whl", hash = "sha256:e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3", size = 1228782 },
 ]
+
+[[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750 }
 
 [[package]]
 name = "shellingham"


### PR DESCRIPTION
closes #243 
## Overview

Adds a route for extracting some metadata about a related paper from an arxiv.org link. The link can either point to the pdf on arxiv or the paper's regular page. 


## Discussion

I made a new pydantic base class for related metadata schemas so that they will include rather than ignore any fields they weren't explicitly expecting. More relaxed schemas make sense for this kind of metadata, since these are fields we persist as opaque json and don't _really_ care about the exact fields the user/external api has provided for us 


## Testing

manually with a few links I grabbed at random off of arxiv. I also added a couple tiny sanity-tests to make sure the arXiv ID is extracted correctly for both pdf and regular links 
