### PR TITLE
PATCH /gardens can update modal_function_ids 

### DIFF
--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -266,7 +266,21 @@ async def update_garden(
                 detail="Cannot update a published garden's entrypoints.",
             )
         # collect entrypoints by DOI
-        garden.entrypoints = await _collect_entrypoints(garden_data.entrypoint_ids, db)
+        garden.entrypoints = await _collect_entrypoints(
+            garden_data.entrypoint_ids or [], db
+        )
+
+    # Prevent updating modal functions on published gardens
+    if "modal_function_ids" in garden_patch_dict:
+        if not garden.doi_is_draft:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot update a published garden's entrypoints.",
+            )
+        # collect entrypoints by DOI
+        garden.modal_functions = await _collect_modal_functions(
+            garden_data.modal_function_ids or [], db
+        )
 
     for key, value in garden_patch_dict.items():
         setattr(garden, key, value)

--- a/garden-backend-service/src/api/schemas/garden.py
+++ b/garden-backend-service/src/api/schemas/garden.py
@@ -59,10 +59,11 @@ class GardenPatchRequest(BaseSchema):
     language: str | None = None
     tags: UniqueList[str] | None = None
     version: str | None = None
-    entrypoint_aliases: dict[str, str] = None
+    entrypoint_aliases: dict[str, str] | None = None
     is_archived: bool | None = None
     is_test: bool | None = None
     entrypoint_ids: UniqueList[str] | None = None
+    modal_function_ids: UniqueList[int] | None = None
 
 
 class GardenSearchFilter(BaseSchema):


### PR DESCRIPTION
## Overview

Turns out we didn't actually support updating the `modal_function_ids` attribute on existing gardens, since it didn't exist in the schema for PATCH requests (but does for creating new ones). oops!

## Testing

If I'm being completely honest I didn't test it at all yet due to the fact that this is just copy-pasting a block of existing entrypoints code. I'll eat a hat if this breaks anything 🤠 