### PR TITLE
fix f-string ast bug

### DIFF
--- a/garden-backend-service/src/modal/user_file_parsing.py
+++ b/garden-backend-service/src/modal/user_file_parsing.py
@@ -197,11 +197,18 @@ def _update_image_info_from_root_staticmethod(
         # Case 1: constructed with `Image.from_registry`
         case ast.Call(
             func=ast.Attribute(attr="from_registry"),
-            args=[ast.Constant(value=str(base_image_tag))],
+            args=[arg],
             keywords=keywords,
         ):
-            # save the explicit base image
-            new_info.base_image = base_image_tag
+            match arg:
+                # case 1a: image is referred to by a plain string
+                case ast.Constant(value=str(base_image_tag)):
+                    # save the explicit base image
+                    new_info.base_image = base_image_tag
+                case _:
+                    # else, if the arg is not a constant (e.g. it's an f-string or variable)
+                    # we can't reliably infer a base image
+                    new_info.base_image = "n/a"
             for kw in keywords:
                 if kw.arg == "add_python" and isinstance(kw.value, ast.Constant):
                     new_info.python_version = str(kw.value.value)

--- a/garden-backend-service/tests/api/routes/modal/test_modal_file_metadata.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_file_metadata.py
@@ -10,6 +10,7 @@ from tests.fixtures.modal_file_constants import (
     VALID_BASIC_IMPORTS,
     VALID_CLASS_BASED,
     VALID_CONDA_PACKAGES,
+    VALID_F_STRING_FROM_REGISTRY,
     VALID_MULTIPLE_IMAGE_VARIABLE_REFERENCES,
     VALID_MULTIPLE_IMAGES,
     VALID_MULTIPLE_LOCAL_ENTRYPOINTS,
@@ -135,6 +136,22 @@ async def test_validate_multiple_image_variables(client, _metadata_validation_fi
                 "torch",
                 "transformers",
             }
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_validate_fstring_from_registry(client, _metadata_validation_fixtures):
+    response = await client.post(
+        "/modal-file-metadata", json={"file_contents": VALID_F_STRING_FROM_REGISTRY}
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    _assert_response_metadata(
+        data,
+        "valid-fstring-from-registry-app",
+        expected_base_image="n/a",
+    )
 
 
 @pytest.mark.asyncio

--- a/garden-backend-service/tests/fixtures/modal_file_constants.py
+++ b/garden-backend-service/tests/fixtures/modal_file_constants.py
@@ -236,7 +236,7 @@ def ml_stuff():
 VALID_F_STRING_FROM_REGISTRY = """
 import modal
 
-app = modal.App("valid-fstring-from-registry-app")
+
 alignn_image = (
     modal.Image.from_registry(f"nvidia/cuda:12.4.0-devel-ubuntu22.04", add_python="3.10")
     .apt_install("git")
@@ -253,4 +253,11 @@ alignn_image = (
         "pyyaml"
     )
 )   
+
+app = modal.App("valid-fstring-from-registry-app", image=alignn_image)
+
+@app.function(image=alignn_image, gpu="A100")
+def alignn_stuff():
+    import alignn
+    return alignn.predict("Hello, world!")
 """

--- a/garden-backend-service/tests/fixtures/modal_file_constants.py
+++ b/garden-backend-service/tests/fixtures/modal_file_constants.py
@@ -233,3 +233,24 @@ def ml_stuff():
     return torch.rand(10)
 
 """
+VALID_F_STRING_FROM_REGISTRY = """
+import modal
+
+app = modal.App("valid-fstring-from-registry-app")
+alignn_image = (
+    modal.Image.from_registry(f"nvidia/cuda:12.4.0-devel-ubuntu22.04", add_python="3.10")
+    .apt_install("git")
+    .pip_install("numpy==1.26.4")
+    .run_commands(
+        "pip install  dgl -f https://data.dgl.ai/wheels/torch-2.4/cu124/repo.html",
+        "pip install alignn"
+    )
+    .pip_install(
+        "jarvis-tools",
+        "torch==2.5.0",
+        "torchdata==0.9.0",
+        "scipy",
+        "pyyaml"
+    )
+)   
+"""


### PR DESCRIPTION
## Overview

Fixes the bug riya discovered where an f-string in the `from_registry` method would cause validation to fail. 

Trying to reliably infer the base image when we hit an f-string node would be overly complex (and plausibly not possible to handle pathological cases). So instead of failing when we can't infer the exact base image, we can leave it at 'n/a'.

## Testing

Added a new unit test with the snippet of riya's code that surfaced the error in the first place 