### PR TITLE
add plural GET /modal-functions route

### DIFF
--- a/garden-backend-service/src/api/routes/modal/modal_functions.py
+++ b/garden-backend-service/src/api/routes/modal/modal_functions.py
@@ -73,9 +73,9 @@ async def get_modal_functions(
         )
     if draft is not None:
         if draft:
-            stmt = stmt.where(ModalFunction.doi is None)
+            stmt = stmt.where(ModalFunction.doi == None)  # noqa: E711
         else:
-            stmt = stmt.where(ModalFunction.doi is not None)
+            stmt = stmt.where(ModalFunction.doi != None)  # noqa: E711
     if year:
         stmt = stmt.where(ModalFunction.year == year)
 

--- a/garden-backend-service/src/api/routes/modal/modal_functions.py
+++ b/garden-backend-service/src/api/routes/modal/modal_functions.py
@@ -1,4 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
@@ -35,6 +39,48 @@ async def get_modal_function(
             detail=f"Modal Function not found with id {id}",
         )
     return modal_function
+
+
+@router.get("", status_code=status.HTTP_200_OK)
+async def get_modal_functions(
+    db: AsyncSession = Depends(get_db_session),
+    *,
+    id: list[int] | None = Query(None),
+    doi: list[str] | None = Query(None),
+    tags: list[str] | None = Query(None),
+    authors: list[str] | None = Query(None),
+    owner_uuid: UUID | None = Query(None),
+    draft: bool | None = Query(None),
+    year: str | None = Query(None),
+    limit: int = Query(50, le=100),
+) -> list[ModalFunctionMetadataResponse]:
+    """Fetch multiple modal functions according to query parameters."""
+    stmt = select(ModalFunction)
+
+    if id:
+        stmt = stmt.where(ModalFunction.id.in_(id))
+    if doi:
+        stmt = stmt.where(ModalFunction.doi.in_(doi))
+    if tags:
+        stmt = stmt.where(ModalFunction.tags.overlap(array(tags)))
+    if authors:
+        stmt = stmt.where(ModalFunction.authors.overlap(array(authors)))
+    if owner_uuid:
+        stmt = (
+            stmt.join(ModalFunction.modal_app)
+            .join(User)
+            .where(User.identity_id == owner_uuid)
+        )
+    if draft is not None:
+        if draft:
+            stmt = stmt.where(ModalFunction.doi is None)
+        else:
+            stmt = stmt.where(ModalFunction.doi is not None)
+    if year:
+        stmt = stmt.where(ModalFunction.year == year)
+
+    result = await db.scalars(stmt.limit(limit))
+    return result.all()
 
 
 @router.patch("/{id}", response_model=ModalFunctionMetadataResponse)

--- a/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
@@ -28,6 +28,91 @@ async def test_get_modal_function(
 
 @pytest.mark.asyncio
 @pytest.mark.integration
+async def test_get_modal_functions(
+    client,
+    mock_db_session,
+    mock_modal_publisher_auth_state,
+    mock_modal_app_create_request_one_function,
+    override_sandboxed_functions,
+):
+    # Create a modal app which adds a modal function
+    create_app_response = await post_modal_app(
+        client, mock_modal_app_create_request_one_function
+    )
+
+    # Test getting all modal functions
+    response = await client.get("/modal-functions")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) >= 1
+
+    # Test filtering by ID
+    created_function_id = create_app_response["modal_functions"][0]["id"]
+    response = await client.get(f"/modal-functions?id={created_function_id}")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 1
+    assert response_data[0]["id"] == created_function_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_modal_functions_with_tags(
+    client,
+    mock_db_session,
+    mock_modal_publisher_auth_state,
+    mock_modal_app_create_request_one_function,
+    override_sandboxed_functions,
+):
+    # Create a modal app with a function that has tags
+    app_data = mock_modal_app_create_request_one_function.copy()
+    app_data["modal_functions"][0]["tags"] = ["tag1", "tag2"]
+
+    await post_modal_app(client, app_data)
+
+    # Test filtering by tag
+    response = await client.get("/modal-functions?tags=tag1")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) >= 1
+    assert "tag1" in response_data[0]["tags"]
+
+    # Test filtering by non-existent tag
+    response = await client.get("/modal-functions?tags=non-existent-tag")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_modal_functions_with_draft(
+    client,
+    mock_db_session,
+    mock_modal_publisher_auth_state,
+    mock_modal_app_create_request_one_function,
+    override_sandboxed_functions,
+):
+    # Create a modal app with a function (draft by default since doi is null)
+    await post_modal_app(client, mock_modal_app_create_request_one_function)
+
+    # Test filtering by draft status
+    response = await client.get("/modal-functions?draft=true")
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data) >= 1
+    assert response_data[0]["doi"] is None
+
+    # Test filtering by published status
+    response = await client.get("/modal-functions?draft=false")
+    assert response.status_code == 200
+    response_data = response.json()
+    # Should be empty since all functions are drafts
+    assert len(response_data) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
 async def test_patch_modal_function_partial_update(
     client,
     mock_db_session,


### PR DESCRIPTION
Another quick 🤠 PR to add a GET /modal-functions route with query params (instead of just GET /modal-functions/{id})

## Testing

Included some new unit tests and light manual testing seems sane. Not surprising since this was basically copy-pasted from the equivalent entrypoints route 