### PR TITLE
Make it so that a garden can be saved more than once

### DIFF
--- a/garden-backend-service/migrations/versions/bed2401f656e_make_sure_garden_user_relation_has_a_.py
+++ b/garden-backend-service/migrations/versions/bed2401f656e_make_sure_garden_user_relation_has_a_.py
@@ -1,0 +1,39 @@
+"""make sure garden-user relation has a joint pk
+
+Revision ID: bed2401f656e
+Revises: 4d528e79513e
+Create Date: 2025-03-20 21:27:41.183331
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "bed2401f656e"
+down_revision: Union[str, None] = "4d528e79513e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Drop the existing primary key constraint
+    op.drop_constraint(
+        "users_saved_gardens_pkey", "users_saved_gardens", type_="primary"
+    )
+    # Create a new composite primary key
+    op.create_primary_key(
+        "users_saved_gardens_pkey", "users_saved_gardens", ["user_id", "garden_id"]
+    )
+
+
+def downgrade() -> None:
+    # Drop the composite primary key
+    op.drop_constraint(
+        "users_saved_gardens_pkey", "users_saved_gardens", type_="primary"
+    )
+    # Recreate the original primary key on garden_id only
+    op.create_primary_key(
+        "users_saved_gardens_pkey", "users_saved_gardens", ["garden_id"]
+    )

--- a/garden-backend-service/src/models/_associations.py
+++ b/garden-backend-service/src/models/_associations.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, ForeignKey, Integer, Table
+from sqlalchemy import Column, ForeignKey, Integer, PrimaryKeyConstraint, Table
 
 from src.models.base import Base
 
@@ -19,8 +19,9 @@ gardens_modal_functions = Table(
 users_saved_gardens = Table(
     "users_saved_gardens",
     Base.metadata,
-    Column("user_id", Integer, ForeignKey("users.id"), primary_key=True),
-    Column("garden_id", Integer, ForeignKey("gardens.id"), primary_key=True),
+    Column("user_id", Integer, ForeignKey("users.id")),
+    Column("garden_id", Integer, ForeignKey("gardens.id")),
+    PrimaryKeyConstraint("user_id", "garden_id"),
 )
 
 entrypoints_mdf_datasets = Table(


### PR DESCRIPTION
Fixes https://github.com/Garden-AI/garden-frontend/issues/267

## Overview

There were 409 (conflict) errors happening when you tried to save/bookmark a garden. It appears that the root cause here was a weird translation from ORM to SQL, leading in a primary key constraint we didn't want. The user<->garden relation table had a primary key constraint on garden. (So the first user to claim a garden is the only one able to save it!) What we wanted was a joint constraint on (user, garden) pairs. This PR updates the constraint to reflect that.

## Discussion

There is a warning when running the migrations from scratch to the effect of 

> garden-backend-service-api-1      | /app/migrations/versions/f293268b31c5_add_fields_to_users_table_createusers.py:24: SAWarning: Table 'users_saved_gardens' specifies columns 'user_id' as primary_key=True, not matching locally specified columns 'garden_id'; setting the current primary key columns to 'garden_id'. This warning may become an exception in a future release

I'm still mystified as to how the migration got created this way when it went fine for our other relation tables.

## Testing

I made sure the migration runs cleanly, and I plan on doing a final end to end test in staging.