### PR TITLE
Eagerly load saved gardens to avoid async serialization error

### DIFF
--- a/garden-backend-service/src/models/user.py
+++ b/garden-backend-service/src/models/user.py
@@ -28,5 +28,5 @@ class User(Base):
     saved_gardens: Mapped[list["Garden"]] = relationship(
         "Garden",
         secondary=users_saved_gardens,
-        lazy="select",
+        lazy="selectin",
     )


### PR DESCRIPTION
Fast follow to #256. I was testing in staging and noticed occasional 500's on saving operations. Logs looked like this:
```
[21/Mar/2025:16:22:19] INFO: 172.26.53.0:22590 - "PUT /users/6c9e223f-c215-4c26-9abb-262dbce0001c/saved/gardens/10.23677/kga9-nc58 HTTP/1.1" 200 OK
[21/Mar/2025:16:22:21] event="Saved garden" level=info doi=10.23677/m4ek-bd27 func_name=save_garden request_id=1615c3b4-73ec-4084-a50e-501fcad742c2 timestamp=2025-03-21T16:22:21.907435Z user_identity_id=6c9e223f-c215-4c26-9abb-262dbce0001c username=willengler@uchicago.edu
[21/Mar/2025:16:22:21] event="Unhandled exception: 4 validation errors:\n {'type': 'get_attribute_error', 'loc': ('response', 2, 'owner_identity_id'), 'msg': \"Error extracting attribute: MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s)\", 'input': <src.models.garden.Garden object at 0x7f41548ef710>, 'ctx': {'error': \"MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s)\"}}\n {'type': 'get_attribute_error', 'loc': ('response', 3, 'owner_identity_id'), 'msg': \"Error extracting attribute: MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s)\", 'input': <src.models.garden.Garden object at 0x7f41548ed460>, 'ctx': {'error': \"MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s)\"}}\n {'type': 'get_attribute_error', 'loc': ('response', 3, 'entrypoints', 0, 'owner_identity_id'), 'msg': \"Error extracting attribute: MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s)\", 'input': <src.models.entrypoint.Entrypoint object at 0x7f41549100b0>, 'ctx': {'error': \"MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s)\"}}\n {'type': 'get_attribute_error', 'loc': ('response', 4, 'owner_identity_id'), 'msg': \"Error extracting attribute: MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s)\", 'input': <src.models.garden.Garden object at 0x7f41548ef650>, 'ctx': {'error': \"MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s)\"}}\n" level=error func_name=error_handling_middleware method=PUT path=/users/6c9e223f-c215-4c26-9abb-262dbce0001c/saved/gardens/10.23677/m4ek-bd27 request_id=1615c3b4-73ec-4084-a50e-501fcad742c2 stack_trace="File \"/app/src/middleware/logging.py\", line 62, in error_handling_middleware\n return await call_next(request)File \"/app/.venv/lib/python3.12/site-packages/starlette/middleware/base.py\", line 154, in call_next\n raise app_excFile \"/app/.venv/lib/python3.12/site-packages/starlette/middleware/base.py\", line 141, in coro\n await self.app(scope, receive_or_disconnect, send_no_error)File \"/app/.venv/lib/python3.12/site-packages/starlette/middleware/cors.py\", line 93, in __call__\n await self.simple_response(scope, receive, send, request_headers=headers)File \"/app/.venv/lib/python3.12/site-packages/starlette/middleware/cors.py\", line 144, in simple_response\n await self.app(scope, receive, send)File \"/app/.venv/lib/python3.12/site-packages/starlette/middleware/exceptions.py\", line 62, in __call__\n await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)File \"/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py\", line 53, in wrapped_app\n raise excFile \"/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py\", line 42, in wrapped_app\n await app(scope, receive, sender)File \"/app/.venv/lib/python3.12/site-packages/starlette/routing.py\", line 715, in __call__\n await self.middleware_stack(scope, receive, send)File \"/app/.venv/lib/python3.12/site-packages/starlette/routing.py\", line 735, in app\n await route.handle(scope, receive, send)File \"/app/.venv/lib/python3.12/site-packages/starlette/routing.py\", line 288, in handle\n await self.app(scope, receive, send)File \"/app/.venv/lib/python3.12/site-packages/starlette/routing.py\", line 76, in app\n await wrap_app_handling_exceptions(app, request)(scope, receive, send)File \"/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py\", line 53, in wrapped_app\n raise excFile \"/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py\", line 42, in wrapped_app\n await app(scope, receive, sender)File \"/app/.venv/lib/python3.12/site-packages/starlette/routing.py\", line 73, in app\n response = await f(request)File \"/app/.venv/lib/python3.12/site-packages/fastapi/routing.py\", line 327, in app\n content = await serialize_response(File \"/app/.venv/lib/python3.12/site-packages/fastapi/routing.py\", line 176, in serialize_response\n raise ResponseValidationError(" timestamp=2025-03-21T16:22:21.915290Z
```

It seems like there was some kind of race condition on lazy loading gardens from the user object at response serialization time. Changing to `selectin` should load the gardens more eagerly and avoid this