### PR TITLE
Load even more eagerly

### DIFF
--- a/garden-backend-service/src/api/routes/users.py
+++ b/garden-backend-service/src/api/routes/users.py
@@ -2,7 +2,7 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import select, selectinload
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
@@ -127,7 +127,18 @@ async def save_garden(
     try:
         await db.commit()
         logger.info("Saved garden", doi=doi)
-        return user.saved_gardens
+        # Explicitly fetch gardens with all needed relationships
+        garden_ids = [g.id for g in user.saved_gardens]
+        stmt = (
+            select(Garden)
+            .where(Garden.id.in_(garden_ids))
+            .options(selectinload(Garden.owner), selectinload(Garden.modal_functions))
+        )
+        result = await db.execute(stmt)
+        gardens = result.scalars().all()
+
+        return gardens
+
     except IntegrityError as e:
         await db.rollback()
         raise HTTPException(
@@ -173,10 +184,16 @@ async def remove_saved_garden(
     try:
         logger.info("Removed saved garden", doi=doi)
         await db.commit()
-        return [
-            GardenMetadataResponse.model_validate(garden)
-            for garden in user.saved_gardens
-        ]
+        garden_ids = [g.id for g in user.saved_gardens]
+        stmt = (
+            select(Garden)
+            .where(Garden.id.in_(garden_ids))
+            .options(selectinload(Garden.owner), selectinload(Garden.modal_functions))
+        )
+        result = await db.execute(stmt)
+        gardens = result.scalars().all()
+
+        return gardens
     except IntegrityError as e:
         await db.rollback()
         raise HTTPException(

--- a/garden-backend-service/src/api/routes/users.py
+++ b/garden-backend-service/src/api/routes/users.py
@@ -2,9 +2,10 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select, selectinload
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
 from src.api.dependencies.auth import authed_user


### PR DESCRIPTION
Follow-up to #257. Still seeing async serialization errors on backend. This PR tries to even more explicitly eagerly load the user-garden relationship
