### PR TITLE
Metadata response schema tweaks

### DIFF
--- a/garden-backend-service/src/api/schemas/garden.py
+++ b/garden-backend-service/src/api/schemas/garden.py
@@ -32,8 +32,8 @@ class GardenCreateRequest(GardenMetadata):
 
 
 class GardenMetadataResponse(GardenMetadata):
-    owner: str = Field(alias=AliasPath("owner", "name"))
-    owner_identity_id: UUID = Field(alias=AliasPath("owner", "identity_id"))
+    owner: str = Field(validation_alias=AliasPath("owner", "name"))
+    owner_identity_id: UUID = Field(validation_alias=AliasPath("owner", "identity_id"))
     id: int
     entrypoints: list[EntrypointMetadataResponse] = Field(default_factory=list)
     modal_functions: list[ModalFunctionMetadataResponse] = Field(default_factory=list)

--- a/garden-backend-service/src/api/schemas/garden.py
+++ b/garden-backend-service/src/api/schemas/garden.py
@@ -32,6 +32,7 @@ class GardenCreateRequest(GardenMetadata):
 
 
 class GardenMetadataResponse(GardenMetadata):
+    owner: str = Field(alias=AliasPath("owner", "name"))
     owner_identity_id: UUID = Field(alias=AliasPath("owner", "identity_id"))
     id: int
     entrypoints: list[EntrypointMetadataResponse] = Field(default_factory=list)

--- a/garden-backend-service/src/api/schemas/modal/modal_function.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_function.py
@@ -1,4 +1,6 @@
-from pydantic import Field
+from uuid import UUID
+
+from pydantic import AliasPath, Field
 
 from ..shared_function_schemas import CommonFunctionMetadata, CommonFunctionPatchRequest
 
@@ -18,6 +20,8 @@ class ModalFunctionMetadata(CommonFunctionMetadata):
 class ModalFunctionMetadataResponse(ModalFunctionMetadata):
     id: int = Field(..., description="The unique identifier for the modal function")
     modal_app_id: int
+    owner: str = Field(validation_alias=AliasPath("owner", "name"))
+    owner_identity_id: UUID = Field(validation_alias=AliasPath("owner", "identity_id"))
 
 
 class ModalFunctionPatchRequest(CommonFunctionPatchRequest):

--- a/garden-backend-service/src/api/schemas/shared_function_schemas.py
+++ b/garden-backend-service/src/api/schemas/shared_function_schemas.py
@@ -1,4 +1,4 @@
-from pydantic import AliasPath, Field
+from pydantic import Field
 
 from .base import BaseRelatedMetadataSchema, BaseSchema, UniqueList, Url
 
@@ -40,7 +40,6 @@ class _NotebookMetadata(BaseRelatedMetadataSchema):
 
 
 class CommonFunctionMetadata(BaseSchema):
-    owner: str = Field(alias=AliasPath("owner", "name"))
     is_archived: bool = False
 
     function_text: str

--- a/garden-backend-service/src/api/schemas/shared_function_schemas.py
+++ b/garden-backend-service/src/api/schemas/shared_function_schemas.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import AliasPath, Field
 
 from .base import BaseRelatedMetadataSchema, BaseSchema, UniqueList, Url
 
@@ -40,6 +40,7 @@ class _NotebookMetadata(BaseRelatedMetadataSchema):
 
 
 class CommonFunctionMetadata(BaseSchema):
+    owner: str = Field(alias=AliasPath("owner", "name"))
     is_archived: bool = False
 
     function_text: str


### PR DESCRIPTION
Helper PR for https://github.com/Garden-AI/garden-frontend/pull/301

Adds `owner` fields to Garden and Function metadata responses. Facilitates easy access to the name of the owner for populating the metadata sidebar on the FE.