### PR TITLE
Allow garden devs to edit any garden/function

### DIFF
--- a/garden-backend-service/src/api/routes/_utils.py
+++ b/garden-backend-service/src/api/routes/_utils.py
@@ -17,6 +17,13 @@ from src.models._associations import gardens_entrypoints
 
 logger = get_logger(__name__)
 
+SUPER_USERS: list[str] = [
+    "c8741264-d274-11e5-bee7-f30dff9f1ea8",  # Ben
+    "6c9e223f-c215-4c26-9abb-262dbce0001c",  # Will
+    "76024960-c68b-4fec-8cb8-b65b096f18da",  # Owen
+    "e9a17e09-657b-4087-a719-241ab72b1d9b",  # Hayden
+]
+
 
 def assert_deletable_by_user(obj: Garden | Entrypoint, user: User) -> None:
     """Check that a given Garden or Entrypoint is safe to delete, i.e. has a draft DOI and is owned by the user.
@@ -25,7 +32,10 @@ def assert_deletable_by_user(obj: Garden | Entrypoint, user: User) -> None:
 
         HTTPException: if obj is not owned by user or has a registered 'findable' DOI
     """
-    if obj.owner.identity_id != user.identity_id:
+    if (
+        obj.owner.identity_id != user.identity_id
+        or str(user.identity_id) not in SUPER_USERS
+    ):
         logger.info(
             f"Failed to delete or replace object {str(type(obj).__name__).lower()} (not owned by user)"
         )
@@ -54,8 +64,10 @@ def assert_editable_by_user(
     Raises:
         HTTPException: If obj is not owned by user or is an archived resource (and resource is not being unarchived).
     """
-
-    if obj.owner.identity_id != user.identity_id:
+    if (
+        obj.owner.identity_id != user.identity_id
+        or str(user.identity_id) not in SUPER_USERS
+    ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=f"Failed to edit {str(type(obj).__name__).lower()} (not owned by user {user.username})",

--- a/garden-backend-service/src/api/routes/_utils.py
+++ b/garden-backend-service/src/api/routes/_utils.py
@@ -17,13 +17,6 @@ from src.models._associations import gardens_entrypoints
 
 logger = get_logger(__name__)
 
-SUPER_USERS: list[str] = [
-    "c8741264-d274-11e5-bee7-f30dff9f1ea8",  # Ben
-    "6c9e223f-c215-4c26-9abb-262dbce0001c",  # Will
-    "76024960-c68b-4fec-8cb8-b65b096f18da",  # Owen
-    "e9a17e09-657b-4087-a719-241ab72b1d9b",  # Hayden
-]
-
 
 def assert_deletable_by_user(obj: Garden | Entrypoint, user: User) -> None:
     """Check that a given Garden or Entrypoint is safe to delete, i.e. has a draft DOI and is owned by the user.
@@ -34,7 +27,7 @@ def assert_deletable_by_user(obj: Garden | Entrypoint, user: User) -> None:
     """
     if (
         obj.owner.identity_id != user.identity_id
-        or str(user.identity_id) not in SUPER_USERS
+        or str(user.identity_id) not in Settings.SUPER_USERS
     ):
         logger.info(
             f"Failed to delete or replace object {str(type(obj).__name__).lower()} (not owned by user)"
@@ -66,7 +59,7 @@ def assert_editable_by_user(
     """
     if (
         obj.owner.identity_id != user.identity_id
-        or str(user.identity_id) not in SUPER_USERS
+        or str(user.identity_id) not in Settings.SUPER_USERS
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/garden-backend-service/src/api/routes/_utils.py
+++ b/garden-backend-service/src/api/routes/_utils.py
@@ -11,7 +11,7 @@ from structlog import get_logger
 from src.api.schemas.entrypoint import EntrypointPatchRequest
 from src.api.schemas.garden import GardenPatchRequest
 from src.api.schemas.modal.modal_function import ModalFunctionPatchRequest
-from src.config import Settings
+from src.config import Settings, get_settings
 from src.models import Entrypoint, Garden, ModalFunction, User
 from src.models._associations import gardens_entrypoints
 
@@ -22,12 +22,11 @@ def assert_deletable_by_user(obj: Garden | Entrypoint, user: User) -> None:
     """Check that a given Garden or Entrypoint is safe to delete, i.e. has a draft DOI and is owned by the user.
 
     Raises:
-
         HTTPException: if obj is not owned by user or has a registered 'findable' DOI
     """
     if (
         obj.owner.identity_id != user.identity_id
-        or str(user.identity_id) not in Settings.SUPER_USERS
+        and str(user.identity_id) not in get_settings().SUPER_USERS
     ):
         logger.info(
             f"Failed to delete or replace object {str(type(obj).__name__).lower()} (not owned by user)"
@@ -59,7 +58,7 @@ def assert_editable_by_user(
     """
     if (
         obj.owner.identity_id != user.identity_id
-        or str(user.identity_id) not in Settings.SUPER_USERS
+        and str(user.identity_id) not in get_settings().SUPER_USERS
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/garden-backend-service/src/config.py
+++ b/garden-backend-service/src/config.py
@@ -69,6 +69,12 @@ class Settings(BaseSettings):
     MODAL_USAGE_LIMIT: float = 5.0
     MODAL_TIMEOUT_SECONDS: float = 25.0
     MODAL_PUBLISHERS_GROUP_ID: str = "84d1669a-9d51-11ef-8d7c-1769556b58bd"
+    SUPER_USERS: list[str] = [
+        "c8741264-d274-11e5-bee7-f30dff9f1ea8",  # Ben
+        "6c9e223f-c215-4c26-9abb-262dbce0001c",  # Will
+        "76024960-c68b-4fec-8cb8-b65b096f18da",  # Owen
+        "e9a17e09-657b-4087-a719-241ab72b1d9b",  # Hayden
+    ]
 
     GARDEN_SEARCH_SQL_DIR: str = "src/api/search/sql.sql"
 

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -298,6 +298,12 @@ def mock_settings(db_url):
     mock_settings.GARDEN_SEARCH_SQL_DIR = "src/api/search/sql.sql"
     mock_settings.MODAL_USAGE_LIMIT = 5.0
     mock_settings.MODAL_TIMEOUT_SECONDS = 10.0
+    mock_settings.SUPER_USERS = [
+        "c8741264-d274-11e5-bee7-f30dff9f1ea8",  # Ben
+        "6c9e223f-c215-4c26-9abb-262dbce0001c",  # Will
+        "76024960-c68b-4fec-8cb8-b65b096f18da",  # Owen
+        "e9a17e09-657b-4087-a719-241ab72b1d9b",  # Hayden
+    ]
     return mock_settings
 
 

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -303,7 +303,6 @@ def mock_settings(db_url):
         "6c9e223f-c215-4c26-9abb-262dbce0001c",  # Will
         "76024960-c68b-4fec-8cb8-b65b096f18da",  # Owen
         "e9a17e09-657b-4087-a719-241ab72b1d9b",  # Hayden
-        "00000000-0000-0000-0000-000000000000",  # Mock test user
     ]
     return mock_settings
 

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -303,6 +303,7 @@ def mock_settings(db_url):
         "6c9e223f-c215-4c26-9abb-262dbce0001c",  # Will
         "76024960-c68b-4fec-8cb8-b65b096f18da",  # Owen
         "e9a17e09-657b-4087-a719-241ab72b1d9b",  # Hayden
+        "00000000-0000-0000-0000-000000000000",  # Mock test user
     ]
     return mock_settings
 


### PR DESCRIPTION
Related FE PR: https://github.com/Garden-AI/garden-frontend/pull/309

## Overview

This PR adds a list of `SUPER_USERS` (the garden dev team) that bypasses the `assert_editable_by_user` and `assert_deletable_by_user` checks to allow requests from the garden devs to edit garden and function metadata.


## Testing

Manually
