### PR TITLE
Allow volumes and memory snapshotting to be configured

### DIFF
--- a/garden-backend-service/src/modal/user_file_parsing.py
+++ b/garden-backend-service/src/modal/user_file_parsing.py
@@ -23,14 +23,12 @@ FUNCTION_KWARG_BLOCKLIST = {
     "secrets",
     "mounts",
     "network_file_systems",
-    "volumes",
     "allow_cross_region_volumes",
     "proxy",
     "keep_warm",
     "is_generator",
     "cloud",
     "region",
-    "enable_memory_snapshot",
     "block_network",
 }
 


### PR DESCRIPTION
I'd like to use volumes to store the txGemma weights and memory snapshotting to speed up cold starts. It'll be more of a feature to make volumes useful to not just the dev team.