### PR TITLE
Support filtering garden search results by owner/gardener

### DIFF
--- a/garden-backend-service/src/api/schemas/garden.py
+++ b/garden-backend-service/src/api/schemas/garden.py
@@ -74,7 +74,8 @@ class GardenSearchFilter(BaseSchema):
 
 class GardenSearchFacets(BaseSchema):
     tags: dict[str, int] = Field(default_factory=dict)
-    authors: dict[str, int] = Field(default_factory=dict)
+    model_authors: dict[str, int] = Field(default_factory=dict)
+    gardeners: dict[str, int] = Field(default_factory=dict)
     year: dict[str, int] = Field(default_factory=dict)
 
 

--- a/garden-backend-service/src/api/search/utils.py
+++ b/garden-backend-service/src/api/search/utils.py
@@ -8,6 +8,7 @@ from src.api.schemas.garden import (
     GardenSearchFilter,
     GardenSearchSort,
 )
+from src.models import User
 from src.models.base import Base
 
 
@@ -53,7 +54,12 @@ def apply_filters(
         if not hasattr(model, filter.field_name):
             raise ValueError(f"Invalid filter field_name: {filter.field_name}")
         for value in filter.values:
-            if type(getattr(model, filter.field_name).type) is ARRAY:
+            if filter.field_name == "owner":
+                stmt = stmt.join(getattr(model, filter.field_name)).where(
+                    User.name == value
+                )
+                continue
+            if type(getattr(model, filter.field_name)) is ARRAY:
                 stmt = stmt.where(
                     func.array_to_string(getattr(model, filter.field_name), " ").match(
                         value
@@ -85,6 +91,8 @@ async def calculate_facets(db: AsyncSession, query: Select) -> GardenSearchFacet
               are the count of gardens associated with each tag.
             - `authors` (dict[str, int]): A dictionary where keys are author names and values
               are the count of gardens authored by each individual.
+            - `gardeners` (dict[str, int]): A dictionary where keys are gardner names and values
+              are the count of gardens created by each gardener.
             - `year` (dict[str, int]): A dictionary where keys are years (as strings) and values
               are the count of gardens created in each year.
 
@@ -99,9 +107,18 @@ async def calculate_facets(db: AsyncSession, query: Select) -> GardenSearchFacet
     ).group_by(column("tag"))
 
     authors_query = select(
-        func.unnest(filtered_gardens.c.authors).label("author"),
+        func.unnest(filtered_gardens.c.authors).label("model_author"),
         func.count().label("count"),
-    ).group_by(column("author"))
+    ).group_by(column("model_author"))
+
+    gardeners_query = (
+        select(
+            User.name.label("gardener"),
+            func.count().label(name="count"),
+        )
+        .join(filtered_gardens, User.id == filtered_gardens.c.user_id)
+        .group_by(column("gardener"))
+    )
 
     year_query = select(
         filtered_gardens.c.year.label("year"), func.count().label("count")
@@ -109,13 +126,17 @@ async def calculate_facets(db: AsyncSession, query: Select) -> GardenSearchFacet
 
     tags_result = await db.execute(tags_query)
     authors_result = await db.execute(authors_query)
+    gardeners_result = await db.execute(gardeners_query)
     year_result = await db.execute(year_query)
 
     tags = {row[0]: row[1] for row in tags_result.all()}
     authors = {row[0]: row[1] for row in authors_result.all()}
+    gardeners = {row[0]: row[1] for row in gardeners_result.all()}
     year = {str(row[0]): row[1] for row in year_result.all()}
 
-    return GardenSearchFacets(tags=tags, authors=authors, year=year)
+    return GardenSearchFacets(
+        tags=tags, model_authors=authors, gardeners=gardeners, year=year
+    )
 
 
 def sort_results(model: Base, stmt: Select, sort: GardenSearchSort):

--- a/garden-backend-service/tests/api/routes/test_gardens.py
+++ b/garden-backend-service/tests/api/routes/test_gardens.py
@@ -677,7 +677,7 @@ async def test_search_gardens_returns_gardens(
     assert len(search_result["garden_meta"]) == 1
     assert search_result["count"] == 1
     assert search_result["offset"] == 0
-    assert search_result["facets"]["authors"] == {"Owen": 1}
+    assert search_result["facets"]["model_authors"] == {"Owen": 1}
     assert search_result["facets"]["year"] == {"2023": 1}
 
 
@@ -688,6 +688,7 @@ async def test_search_gardens_applies_filters_correctly(
     mock_db_session,
     override_authenticated_dependency,
     mock_garden_create_request_no_entrypoints_json,
+    mock_auth_state,
 ):
     g1 = mock_garden_create_request_no_entrypoints_json
 
@@ -710,6 +711,7 @@ async def test_search_gardens_applies_filters_correctly(
             {"field_name": "authors", "values": ["Owen"]},
             {"field_name": "tags", "values": ["testing"]},
             {"field_name": "description", "values": ["testing"]},
+            {"field_name": "owner", "values": [f"{mock_auth_state.name}"]},
         ],
     }
     response = await client.post("gardens/search", json=body)
@@ -718,7 +720,7 @@ async def test_search_gardens_applies_filters_correctly(
     search_result = response.json()
     assert len(search_result["garden_meta"]) == 1
     assert search_result["garden_meta"][0]["authors"][0] == "Owen"
-    assert search_result["facets"]["authors"] == {"Owen": 1}
+    assert search_result["facets"]["model_authors"] == {"Owen": 1}
     assert search_result
 
 
@@ -767,7 +769,7 @@ async def test_search_gardens_facet_counts_are_correct(
     assert res1.status_code == 200
     search_res1 = res1.json()
     facets1 = search_res1["facets"]
-    assert facets1["authors"]["Owen"] == 3
+    assert facets1["model_authors"]["Owen"] == 3
     assert facets1["tags"]["python"] == 2
     assert facets1["tags"]["testing"] == 1
     assert facets1["year"]["2023"] == 3
@@ -782,7 +784,7 @@ async def test_search_gardens_facet_counts_are_correct(
     assert res2.status_code == 200
     search_res2 = res2.json()
     facets2 = search_res2["facets"]
-    assert facets2["authors"]["Owen"] == 1
+    assert facets2["model_authors"]["Owen"] == 1
     assert facets2["tags"]["testing"] == 1
     assert facets2["year"]["2023"] == 1
 


### PR DESCRIPTION
## Overview

This PR adds support for filtering garden search results by 'Gardeners'.

## Discussion

Essentially just handles adding a where clause to the search filters query if the gardener/owner filter is in the request, and adds a `gardeners` field to the facets schema.

## Testing

Updated existing unit tests.

Tested manually on local FE.
