### PR TITLE
Add get_modal_apps route

### DIFF
--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from modal_proto import api_pb2
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
@@ -191,6 +192,25 @@ def _validate_modal_app_metadata(app_metadata: ModalAppCreateRequest):
             suggested_fix="Make sure function names in the Modal App creation request match the function names in the Modal file",
         )
     return
+
+
+@router.get(
+    "/",
+    status_code=status.HTTP_200_OK,
+    response_model=list[AsyncModalAppMetadataResponse],
+)
+async def get_modal_apps(
+    db: AsyncSession = Depends(get_db_session),
+    user: User = Depends(authed_user),
+):
+    """Get all of the current user's Modal Apps"""
+    query = (
+        select(ModalApp).where(ModalApp.user_id == user.id).order_by(ModalApp.id.desc())
+    )
+    result = await db.execute(query)
+    modal_apps = result.scalars().all()
+    logger.info(f"Found {len(modal_apps)} modal apps for user {user.id}")
+    return modal_apps
 
 
 @router.get(

--- a/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
@@ -145,6 +145,25 @@ async def test_get_modal_app(
 
 @pytest.mark.asyncio
 @pytest.mark.integration
+async def test_get_modal_apps(
+    client,
+    mock_db_session,
+    mock_modal_publisher_auth_state,
+    mock_modal_app_create_request_one_function,
+    override_sandboxed_functions,
+):
+    num_apps = 5
+    for _ in range(num_apps):
+        await post_modal_app(client, mock_modal_app_create_request_one_function)
+
+    get_response = await client.get("/modal-apps/")
+    assert get_response.status_code == 200
+    get_response_data = get_response.json()
+    assert len(get_response_data) == num_apps
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
 async def test_delete_modal_app(
     client,
     mock_db_session,


### PR DESCRIPTION
This PR facilitates https://github.com/Garden-AI/garden-frontend/pull/326

## Overview

Adds a new get route for modal apps that returns all of the logged in users modal apps. Facilitates populating the Model Deployments view on the FE.

## Testing

New unit test