### PR TITLE
Owen/update modal apps inplace

### DIFF
--- a/garden-backend-service/src/api/routes/_utils.py
+++ b/garden-backend-service/src/api/routes/_utils.py
@@ -10,9 +10,10 @@ from structlog import get_logger
 
 from src.api.schemas.entrypoint import EntrypointPatchRequest
 from src.api.schemas.garden import GardenPatchRequest
+from src.api.schemas.modal.modal_app import ModalAppPatchRequest
 from src.api.schemas.modal.modal_function import ModalFunctionPatchRequest
 from src.config import Settings, get_settings
-from src.models import Entrypoint, Garden, ModalFunction, User
+from src.models import Entrypoint, Garden, ModalApp, ModalFunction, User
 from src.models._associations import gardens_entrypoints
 
 logger = get_logger(__name__)
@@ -45,9 +46,12 @@ def assert_deletable_by_user(obj: Garden | Entrypoint, user: User) -> None:
 
 
 def assert_editable_by_user(
-    obj: Garden | Entrypoint | ModalFunction,
+    obj: Garden | Entrypoint | ModalFunction | ModalApp,
     patch_request: (
-        GardenPatchRequest | EntrypointPatchRequest | ModalFunctionPatchRequest
+        GardenPatchRequest
+        | EntrypointPatchRequest
+        | ModalFunctionPatchRequest
+        | ModalAppPatchRequest
     ),
     user: User,
 ) -> None:
@@ -64,11 +68,14 @@ def assert_editable_by_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=f"Failed to edit {str(type(obj).__name__).lower()} (not owned by user {user.username})",
         )
-    elif obj.is_archived and patch_request.is_archived is not False:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Failed to edit {str(type(obj).__name__).lower()} (DOI {obj.doi} is archived)",
-        )
+    elif not isinstance(obj, ModalApp) and not isinstance(
+        patch_request, ModalAppPatchRequest
+    ):  # apps don't have a concept of "archived"
+        if obj.is_archived and patch_request.is_archived is not False:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Failed to edit {str(type(obj).__name__).lower()} (DOI {obj.doi} is archived)",
+            )
 
     return
 

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from modal_proto import api_pb2
-from sqlalchemy import and_, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
@@ -34,7 +34,6 @@ from src.modal import parse_modal_file
 from src.modal.status import AsyncModalJobStatus
 from src.modal.utils import monitor_modal_deployment
 from src.models import ModalApp, ModalFunction, User
-from src.models._associations import gardens_modal_functions
 
 from .modal_file_metadata import parse_modal_file_metadata
 
@@ -190,17 +189,9 @@ async def patch_modal_app(
 
     # otherwise, do a "full publishing flow" with some extra validation
     existing_functions = {fn.function_name: fn for fn in modal_app.modal_functions}
-    # collect function names currently in use by any garden
-    query = select(ModalFunction.function_name).where(
-        and_(
-            ModalFunction.id.in_([fn.id for fn in existing_functions.values()]),
-            ModalFunction.id.in_(
-                select(gardens_modal_functions.c.modal_function_id).distinct()
-            ),
-        )
-    )
-    db_result = await db.execute(query)
-    required_names = set(db_result.scalars().all())
+
+    # TODO: required_names only needs to be functions actually in use
+    required_names = set(existing_functions.keys())
 
     # collect function names from the updated file_contents
     parsed_metadata = await parse_modal_file_metadata(
@@ -227,6 +218,7 @@ async def patch_modal_app(
     hardware_specs = sandbox_metadata["functions"]
 
     # update existing functions or create new ones in the db
+    # TODO: delete functions that are not in use nor present in updated app
     for modal_fn_meta in parsed_metadata.modal_functions:
         name = modal_fn_meta.function_name
         fn_data = modal_fn_meta.model_dump(exclude={"file_contents"})

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from modal_proto import api_pb2
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
@@ -20,17 +20,23 @@ from src.api.dependencies.sandboxed_functions import (
     DeployModalAppProvider,
     ValidateModalFileProvider,
 )
+from src.api.routes._utils import assert_editable_by_user
 from src.api.schemas.modal.modal_app import (
     AsyncModalAppMetadataResponse,
     ModalAppCreateRequest,
     ModalAppMetadataResponse,
+    ModalAppPatchRequest,
+    ModalFileMetadataRequest,
 )
 from src.config import Settings, get_settings
 from src.exceptions.modal import ModalException
 from src.modal import parse_modal_file
 from src.modal.status import AsyncModalJobStatus
 from src.modal.utils import monitor_modal_deployment
-from src.models import ModalApp, User
+from src.models import ModalApp, ModalFunction, User
+from src.models._associations import gardens_modal_functions
+
+from .modal_file_metadata import parse_modal_file_metadata
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/modal-apps")
@@ -144,6 +150,121 @@ async def redeploy_modal_app(
         settings,
     )
 
+    return modal_app
+
+
+@router.patch("/async/{id}", response_model=AsyncModalAppMetadataResponse)
+async def patch_modal_app(
+    id: int,
+    patch_request: ModalAppPatchRequest,
+    background_tasks: BackgroundTasks,
+    db: AsyncSession = Depends(get_db_session),
+    user: User = Depends(authed_user),
+    settings: Settings = Depends(get_settings),
+    validate_modal_file: ValidateModalFileProvider = validate_modal_file_dep,
+    deploy_modal_app: DeployModalAppProvider = deploy_modal_app_dep,
+):
+    """Update a modal app's metadata in-place."""
+    modal_app = await ModalApp.get(db, id=id)
+    if modal_app is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Modal App not found with id {id}",
+        )
+
+    assert_editable_by_user(modal_app, user)
+    # Update other metadata fields provided in request
+    patch_fields = patch_request.model_dump(
+        exclude_none=True, exclude={"file_contents"}
+    )
+    for key, value in patch_fields.items():
+        setattr(modal_app, key, value)
+
+    if patch_request.file_contents is None:
+        # if no changes to file contents, return without re-deploying
+        return modal_app
+    else:
+        modal_app.deploy_status = AsyncModalJobStatus.PENDING
+        modal_app.deploy_error = None
+        modal_app.file_contents = patch_request.file_contents
+
+    # otherwise, do a "full publishing flow" with some extra validation
+    existing_functions = {fn.function_name: fn for fn in modal_app.modal_functions}
+    # collect function names currently in use by any garden
+    query = select(ModalFunction.function_name).where(
+        and_(
+            ModalFunction.id.in_([fn.id for fn in existing_functions.values()]),
+            ModalFunction.id.in_(
+                select(gardens_modal_functions.c.modal_function_id).distinct()
+            ),
+        )
+    )
+    db_result = await db.execute(query)
+    required_names = set(db_result.scalars().all())
+
+    # collect function names from the updated file_contents
+    parsed_metadata = await parse_modal_file_metadata(
+        ModalFileMetadataRequest(file_contents=patch_request.file_contents)
+    )
+    parsed_fn_names = {fn.function_name for fn in parsed_metadata.modal_functions}
+    # updated app must not remove any functions in use
+    if missing_names := required_names - parsed_fn_names:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Function names ({', '.join(missing_names)}) not found in the updated Modal file, but are in use by one or more Gardens.",
+        )
+
+    if parsed_metadata.app_name != modal_app.original_app_name:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"App name mismatch: Got '{parsed_metadata.app_name}' from file but expected '{modal_app.original_app_name}'.",
+        )
+
+    # app looks valid, continue to deploying the app
+    sandbox_metadata = await validate_modal_file(
+        {"file_contents": patch_request.file_contents}
+    )
+    hardware_specs = sandbox_metadata["functions"]
+
+    # update existing functions or create new ones in the db
+    for modal_fn_meta in parsed_metadata.modal_functions:
+        name = modal_fn_meta.function_name
+        fn_data = modal_fn_meta.model_dump(exclude={"file_contents"})
+        # ensure up-to-date hardware spec
+        if "." in name:
+            class_name, _ = name.split(".")
+            # methods will share the same hardware spec as the special
+            # "class.*" modal function
+            fn_data["hardware_spec"] = hardware_specs[f"{class_name}.*"]
+        else:
+            fn_data["hardware_spec"] = hardware_specs[name]
+        # update existing function or create new one
+        if name in existing_functions:
+            # update the existing function with the new metadata
+            for field, value in fn_data.items():
+                setattr(existing_functions[name], field, value)
+        else:
+            # create a new function
+            new_fn = ModalFunction.from_dict(fn_data)
+            modal_app.modal_functions.append(new_fn)
+
+    await db.commit()
+    await db.refresh(modal_app)
+    # finally, redeploy the app
+    deploy_config = {
+        "app_name": modal_app.app_name,
+        "env": settings.MODAL_ENV,
+        "file_contents": patch_request.file_contents,
+        "token_id": settings.MODAL_TOKEN_ID,
+        "token_secret": settings.MODAL_TOKEN_SECRET,
+    }
+    background_tasks.add_task(
+        monitor_modal_deployment,
+        deploy_modal_app,
+        deploy_config,
+        modal_app.id,
+        settings,
+    )
     return modal_app
 
 

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -163,7 +163,10 @@ async def patch_modal_app(
     validate_modal_file: ValidateModalFileProvider = validate_modal_file_dep,
     deploy_modal_app: DeployModalAppProvider = deploy_modal_app_dep,
 ):
-    """Update a modal app's metadata in-place."""
+    """Update a modal app's metadata in-place.
+
+    Triggers a redeployment if file_contents has changed.
+    """
     modal_app = await ModalApp.get(db, id=id)
     if modal_app is None:
         raise HTTPException(
@@ -180,7 +183,8 @@ async def patch_modal_app(
         setattr(modal_app, key, value)
 
     if patch_request.file_contents is None:
-        # if no changes to file contents, return without re-deploying
+        # if no changes to file contents, save and return without re-deploying
+        await db.commit()
         return modal_app
     else:
         modal_app.deploy_status = AsyncModalJobStatus.PENDING

--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -171,7 +171,7 @@ async def patch_modal_app(
             detail=f"Modal App not found with id {id}",
         )
 
-    assert_editable_by_user(modal_app, user)
+    assert_editable_by_user(modal_app, patch_request, user)
     # Update other metadata fields provided in request
     patch_fields = patch_request.model_dump(
         exclude_none=True, exclude={"file_contents"}

--- a/garden-backend-service/src/api/schemas/modal/modal_app.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_app.py
@@ -52,3 +52,10 @@ class ModalFileMetadataRequest(BaseSchema):
 class ModalFileMetadataResponse(ModalAppMetadata):
     # successful POST /modal-file-metadata response should have everything needed for the subsequent CreateRequest
     pass
+
+
+class ModalAppPatchRequest(BaseSchema):
+    base_image_name: str | None = None
+    requirements: list[str] | None = None
+    conda_requirements: list[str] | None = None
+    file_contents: str | None = None

--- a/garden-backend-service/src/modal/utils.py
+++ b/garden-backend-service/src/modal/utils.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Mapping
 
 from modal_proto import api_pb2
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -89,7 +89,7 @@ async def monitor_modal_invocation(
 
 async def monitor_modal_deployment(
     deploy_func: Callable[..., Awaitable[dict]],
-    deploy_config: dict[str, str | bytes],
+    deploy_config: Mapping[str, str | bytes],
     app_id: int,
     settings: Settings,
 ):

--- a/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
@@ -212,3 +212,254 @@ def test_generate_app_names(mock_auth_state):
 
     # assert there are no duplicates
     assert len(set(generated_names)) == num_to_gen
+
+
+@pytest.mark.parametrize(
+    "mock_validate_modal_file_provider",
+    [
+        {
+            "app_name": "test-app",
+            "functions": {
+                "hello": {"cpus": 1, "gpus": "A100", "memory": 256},
+                "goodbye": {"cpus": 1, "gpus": "A100", "memory": 256},
+            },
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_patch_modal_app_name_mismatch(
+    client,
+    mock_db_session,
+    mock_modal_publisher_auth_state,
+    override_sandboxed_functions,
+):
+    # First create an app with a known name
+    initial_app = """
+import modal
+
+app = modal.App(name="test-app")
+
+@app.function()
+def hello():
+    return "Hello, world!"
+"""
+    # Get metadata for the initial app
+    metadata_response = await client.post(
+        "/modal-file-metadata", json={"file_contents": initial_app}
+    )
+    assert metadata_response.status_code == 200
+    metadata = metadata_response.json()
+
+    # Create the app using the metadata directly
+    create_response = await post_modal_app(client, metadata)
+    app_id = create_response["id"]
+
+    # Try to patch with a different app name in the source code
+    patch_data = {
+        "file_contents": """
+import modal
+
+app = modal.App(name="different-app-name")
+
+@app.function()
+def hello():
+    return "Hello, world!"
+"""
+    }
+    response = await client.patch(f"/modal-apps/async/{app_id}", json=patch_data)
+    assert response.status_code == 400
+    assert "App name mismatch" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "mock_validate_modal_file_provider",
+    [
+        {
+            "app_name": "test-app",
+            "functions": {
+                "hello": {"cpus": 1, "gpus": "A100", "memory": 256},
+                "goodbye": {"cpus": 1, "gpus": "A100", "memory": 256},
+            },
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_patch_modal_app_remove_function(
+    client,
+    mock_db_session,
+    mock_modal_publisher_auth_state,
+    override_sandboxed_functions,
+):
+    # First create an app with multiple functions
+    initial_app = """
+import modal
+
+app = modal.App(name="test-app")
+
+@app.function()
+def hello():
+    return "Hello, world!"
+
+@app.function()
+def goodbye():
+    return "Goodbye, world!"
+"""
+    # Get metadata for the initial app
+    metadata_response = await client.post(
+        "/modal-file-metadata", json={"file_contents": initial_app}
+    )
+    assert metadata_response.status_code == 200
+    metadata = metadata_response.json()
+
+    # Create the app using the metadata directly
+    create_response = await post_modal_app(client, metadata)
+    app_id = create_response["id"]
+
+    # Try to patch by removing one of the functions
+    patch_data = {
+        "file_contents": """
+import modal
+
+app = modal.App(name="test-app")
+
+@app.function()
+def hello():
+    return "Hello, world!"
+"""
+    }
+    response = await client.patch(f"/modal-apps/async/{app_id}", json=patch_data)
+    assert response.status_code == 400
+    assert (
+        "Function names (goodbye) not found in the updated Modal file"
+        in response.json()["detail"]
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_validate_modal_file_provider",
+    [
+        {
+            "app_name": "test-app",
+            "functions": {
+                "hello": {"cpus": 1, "gpus": "A100", "memory": 256},
+                "goodbye": {"cpus": 1, "gpus": "A100", "memory": 256},
+            },
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_patch_modal_app_add_function(
+    client,
+    mock_db_session,
+    mock_modal_publisher_auth_state,
+    override_sandboxed_functions,
+):
+    # First create an app with one function
+    initial_app = """
+import modal
+
+app = modal.App(name="test-app")
+
+@app.function()
+def hello():
+    return "Hello, world!"
+"""
+    # Get metadata for the initial app
+    metadata_response = await client.post(
+        "/modal-file-metadata", json={"file_contents": initial_app}
+    )
+    assert metadata_response.status_code == 200
+    metadata = metadata_response.json()
+
+    # Create the app using the metadata directly
+    create_response = await post_modal_app(client, metadata)
+    app_id = create_response["id"]
+
+    # Patch to add a new function
+    patch_data = {
+        "file_contents": """
+import modal
+
+app = modal.App(name="test-app")
+
+@app.function()
+def hello():
+    return "Hello, world!"
+
+@app.function()
+def goodbye():
+    return "Goodbye, world!"
+"""
+    }
+    response = await client.patch(f"/modal-apps/async/{app_id}", json=patch_data)
+    assert response.status_code == 200
+    response_data = response.json()
+    assert len(response_data["modal_functions"]) == 2
+    assert any(
+        fn["function_name"] == "goodbye" for fn in response_data["modal_functions"]
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_validate_modal_file_provider",
+    [
+        {
+            "app_name": "test-app",
+            "functions": {
+                "hello": {"cpus": 1, "gpus": "A100", "memory": 256},
+            },
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_patch_modal_app_modify_function(
+    client,
+    mock_db_session,
+    mock_modal_publisher_auth_state,
+    override_sandboxed_functions,
+):
+    # First create an app
+    initial_app = """
+import modal
+
+app = modal.App(name="test-app")
+
+@app.function()
+def hello():
+    return "Hello, world!"
+"""
+    # Get metadata for the initial app
+    metadata_response = await client.post(
+        "/modal-file-metadata", json={"file_contents": initial_app}
+    )
+    assert metadata_response.status_code == 200
+    metadata = metadata_response.json()
+
+    # Create the app using the metadata directly
+    create_response = await post_modal_app(client, metadata)
+    app_id = create_response["id"]
+
+    # Patch to modify the function
+    patch_data = {
+        "file_contents": """
+import modal
+
+app = modal.App(name="test-app")
+
+@app.function()
+def hello():
+    return "Hello, modified world!"
+"""
+    }
+    response = await client.patch(f"/modal-apps/async/{app_id}", json=patch_data)
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data["deploy_status"] == "pending"


### PR DESCRIPTION
fixes #292 (first part of #277)

## Overview

This PR allows users to update metadata of modal apps they own in-place with `PATCH /modal-apps/async/{id}`. If the `file_contents` field is included in the request body, we reproduce the "full publishing flow" as if we were hitting /modal-file-metadata for validation before re-deploying the app. 

## Discussion

We don't deploy the app if: 
  - the app's name has changed in the source code (bc we deploy the app under a fixed name this isn't technically an obstacle, but is a signal that the user probably picked the wrong file for the update) 
  - The functions defined in the new source code are not a superset of the functions in the old source code. The functions can be redefined as long as they have the same names, in which case their DB entry will be updated in-place. 
    - For now, this is true whether or not they are actually used by any gardens. Follow up PR will include the deletion logic to relax the constraint so that users can omit unused functions. 
## Testing

Manually + some new unit tests 