### PR TITLE
app updates can omit unused functions to delete them

### DIFF
--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from modal_proto import api_pb2
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
@@ -188,64 +188,42 @@ async def patch_modal_app(
         await db.commit()
         return modal_app
     else:
+        # otherwise, do a "full publishing flow" with some extra validation
         modal_app.deploy_status = AsyncModalJobStatus.PENDING
         modal_app.deploy_error = None
         modal_app.file_contents = patch_request.file_contents
 
-    # otherwise, do a "full publishing flow" with some extra validation
-    existing_functions = {fn.function_name: fn for fn in modal_app.modal_functions}
-
-    # TODO: required_names only needs to be functions actually in use
-    required_names = set(existing_functions.keys())
-
-    # collect function names from the updated file_contents
+    # parse contents like /modal-file-metadata route
     parsed_metadata = await parse_modal_file_metadata(
         ModalFileMetadataRequest(file_contents=patch_request.file_contents)
     )
-    parsed_fn_names = {fn.function_name for fn in parsed_metadata.modal_functions}
-    # updated app must not remove any functions in use
-    if missing_names := required_names - parsed_fn_names:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Function names ({', '.join(missing_names)}) not found in the updated Modal file, but are in use by one or more Gardens.",
-        )
-
     if parsed_metadata.app_name != modal_app.original_app_name:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"App name mismatch: Got '{parsed_metadata.app_name}' from file but expected '{modal_app.original_app_name}'.",
         )
 
-    # app looks valid, continue to deploying the app
+    existing_functions = {fn.function_name: fn for fn in modal_app.modal_functions}
+    existing_names = set(existing_functions.keys())
+    parsed_names = {fn.function_name for fn in parsed_metadata.modal_functions}
+
+    # Handle omitted functions if any exist
+    if omitted_names := existing_names - parsed_names:
+        await _handle_omitted_functions(
+            db, modal_app, existing_functions, omitted_names
+        )
+
+    # app looks valid, continue deploying the app
     sandbox_metadata = await validate_modal_file(
         {"file_contents": patch_request.file_contents}
     )
     hardware_specs = sandbox_metadata["functions"]
 
-    # update existing functions or create new ones in the db
-    # TODO: delete functions that are not in use nor present in updated app
-    for modal_fn_meta in parsed_metadata.modal_functions:
-        name = modal_fn_meta.function_name
-        fn_data = modal_fn_meta.model_dump(exclude={"file_contents"})
-        # ensure up-to-date hardware spec
-        if "." in name:
-            class_name, _ = name.split(".")
-            # methods will share the same hardware spec as the special
-            # "class.*" modal function
-            fn_data["hardware_spec"] = hardware_specs[f"{class_name}.*"]
-        else:
-            fn_data["hardware_spec"] = hardware_specs[name]
-        # update existing function or create new one
-        if name in existing_functions:
-            # update the existing function with the new metadata
-            for field, value in fn_data.items():
-                setattr(existing_functions[name], field, value)
-        else:
-            # create a new function
-            new_fn = ModalFunction.from_dict(fn_data)
-            modal_app.modal_functions.append(new_fn)
+    # update/create functions on the app with up-to-date metadata and hardware specs
+    await _update_or_create_modal_functions(
+        db, modal_app, existing_functions, parsed_metadata, hardware_specs
+    )
 
-    await db.commit()
     await db.refresh(modal_app)
     # finally, redeploy the app
     deploy_config = {
@@ -572,3 +550,94 @@ async def _stop_modal_app(
         source=api_pb2.APP_STOP_SOURCE_PYTHON_CLIENT,
     )
     await retry_transient_errors(modal_client.stub.AppStop, stop_request)
+
+
+async def _handle_omitted_functions(
+    db: AsyncSession,
+    modal_app: ModalApp,
+    existing_functions: dict[str, ModalFunction],
+    omitted_names: set[str],
+) -> None:
+    """Handle functions that were omitted from the updated modal file.
+
+    Args:
+        db: Database session
+        modal_app: The modal app being updated
+        existing_functions: Dictionary of existing functions by name
+        omitted_names: Set of existing function names that were omitted from the new file
+    """
+    # query to check for omitted functions still in use by any gardens
+    stmt = (
+        select(ModalFunction.function_name, Garden.title, Garden.doi)
+        .join(Garden.modal_functions)
+        .where(
+            and_(
+                ModalFunction.modal_app_id == modal_app.id,
+                ModalFunction.function_name.in_(omitted_names),
+            )
+        )
+        .distinct()
+    )
+    result = await db.execute(stmt)
+    # mapping of omitted function name -> list of gardens that use it
+    functions_in_use = {}
+    for fn_name, title, doi in result:
+        if fn_name not in functions_in_use:
+            functions_in_use[fn_name] = []
+        functions_in_use[fn_name].append({"title": title, "doi": doi})
+
+    if functions_in_use:
+        err_message = "Functions that are currently in use by Gardens must be included in the updated Modal App:"
+        err_details = []
+        for fn_name, gardens in functions_in_use.items():
+            err_details.append(
+                f"Function '{fn_name}' is used by: {', '.join([f'{g['title']} ({g['doi']})' for g in gardens])}"
+            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{err_message}\n\n" + "\n".join(err_details),
+        )
+    else:
+        # safe to delete omitted functions
+        for name in omitted_names:
+            modal_app.modal_functions.remove(existing_functions[name])
+            await db.delete(existing_functions[name])
+
+
+async def _update_or_create_modal_functions(
+    db: AsyncSession,
+    modal_app: ModalApp,
+    existing_functions: dict[str, ModalFunction],
+    parsed_metadata: Any,
+    hardware_specs: dict[str, dict[str, Any]],
+) -> None:
+    """Update or create modal functions based on parsed metadata.
+
+    Args:
+        db: Database session
+        modal_app: The modal app being updated
+        existing_functions: Dictionary of existing functions by name
+        parsed_metadata: Parsed metadata from the modal file
+        hardware_specs: Hardware specifications for each function
+    """
+    for modal_fn_meta in parsed_metadata.modal_functions:
+        name = modal_fn_meta.function_name
+        fn_data = modal_fn_meta.model_dump(exclude={"file_contents"})
+        # ensure up-to-date hardware spec
+        if "." in name:
+            class_name, _ = name.split(".")
+            # methods will share the same hardware spec as the special
+            # "class.*" modal function
+            fn_data["hardware_spec"] = hardware_specs[f"{class_name}.*"]
+        else:
+            fn_data["hardware_spec"] = hardware_specs[name]
+
+        if name in existing_functions:
+            # update the existing function with the newly parsed metadata
+            for field, value in fn_data.items():
+                setattr(existing_functions[name], field, value)
+        else:
+            new_fn = ModalFunction.from_dict(fn_data)
+            modal_app.modal_functions.append(new_fn)
+
+    await db.commit()

--- a/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
@@ -332,11 +332,11 @@ def hello():
 """
     }
     response = await client.patch(f"/modal-apps/async/{app_id}", json=patch_data)
-    assert response.status_code == 400
-    assert (
-        "Function names (goodbye) not found in the updated Modal file"
-        in response.json()["detail"]
-    )
+    assert response.status_code == 200
+    response_data = response.json()
+    names = {fn["function_name"] for fn in response_data["modal_functions"]}
+    assert "hello" in names
+    assert "goodbye" not in names
 
 
 @pytest.mark.parametrize(
@@ -463,3 +463,96 @@ def hello():
     assert response.status_code == 200
     response_data = response.json()
     assert response_data["deploy_status"] == "pending"
+
+
+@pytest.mark.parametrize(
+    "mock_validate_modal_file_provider",
+    [
+        {
+            "app_name": "test-app",
+            "functions": {
+                "hello": {"cpus": 1, "gpus": "A100", "memory": 256},
+                "goodbye": {"cpus": 1, "gpus": "A100", "memory": 256},
+            },
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_patch_modal_app_cannot_remove_function_in_garden(
+    client,
+    mock_db_session,
+    mock_modal_publisher_auth_state,
+    override_sandboxed_functions,
+):
+    # First create an app with multiple functions
+    initial_app = """
+import modal
+
+app = modal.App(name="test-app")
+
+@app.function()
+def hello():
+    return "Hello, world!"
+
+@app.function()
+def goodbye():
+    return "Goodbye, world!"
+"""
+    # Get metadata for the initial app
+    metadata_response = await client.post(
+        "/modal-file-metadata", json={"file_contents": initial_app}
+    )
+    assert metadata_response.status_code == 200
+    metadata = metadata_response.json()
+
+    # Create the app using the metadata directly
+    create_response = await post_modal_app(client, metadata)
+    app_id = create_response["id"]
+    function_ids = [fn["id"] for fn in create_response["modal_functions"]]
+
+    # Create a garden that references the 'hello' function
+    garden_data = {
+        "title": "Test Garden",
+        "doi": "10.1234/test",
+        "authors": ["Test Author"],
+        "contributors": [],
+        "tags": ["test"],
+        "description": "Test garden",
+        "publisher": "Test Publisher",
+        "year": "2024",
+        "language": "en",
+        "version": "1.0.0",
+        "entrypoint_aliases": {},
+        "modal_function_ids": function_ids,
+    }
+    garden_response = await client.post("/gardens", json=garden_data)
+    assert garden_response.status_code == 200
+
+    # Now try to patch the app by removing the 'hello' function
+    updated_app = """
+import modal
+
+app = modal.App(name="test-app")
+
+@app.function()
+def goodbye():
+    return "Goodbye, world!"
+"""
+    patch_request = {
+        "file_contents": updated_app,
+    }
+    patch_response = await client.patch(
+        f"/modal-apps/async/{app_id}", json=patch_request
+    )
+    assert patch_response.status_code == 400
+    error_data = patch_response.json()
+    assert (
+        "Functions that are currently in use by Gardens must be included"
+        in error_data["detail"]
+    )
+    assert "hello" in error_data["detail"]
+    assert "Test Garden" in error_data["detail"]
+    assert "10.1234/test" in error_data["detail"]
+    assert "goodbye" not in error_data["detail"]


### PR DESCRIPTION
closes #293 (is the second half of and closes #277)

## Overview

This is the second pass at `PATCH /modal-apps`, which now fully handles cases where a user has omitted functions from a new app's definition. If the functions are safe to delete (not referenced by any gardens) they are deleted, otherwise a helpful error message is raised containing the functions that are still referenced by gardens, along with a list of the gardens (by title and doi) which are blocking the update. 

## Discussion

The diff is a little bigger than it strictly needed to be, but I think the route was getting awkwardly long so I cleaned it up a bit / factored out some helper functions. 
## Testing

manually sanity checked, plus included an update to an old test and a new unhappy-path test 
