### PR TITLE
Delete objects marked for deletion

### DIFF
--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -2,13 +2,10 @@ from typing import Any
 from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
-from modal_proto import api_pb2
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
-import modal
-from modal._utils.grpc_utils import retry_transient_errors
 from src.api.dependencies.auth import (
     authed_user,
     in_modal_publishers_group,
@@ -32,7 +29,7 @@ from src.config import Settings, get_settings
 from src.exceptions.modal import ModalException
 from src.modal import parse_modal_file
 from src.modal.status import AsyncModalJobStatus
-from src.modal.utils import monitor_modal_deployment
+from src.modal.utils import monitor_modal_deployment, stop_modal_app
 from src.models import Garden, ModalApp, ModalFunction, User
 from src.models._associations import gardens_modal_functions
 
@@ -360,7 +357,7 @@ async def delete_modal_app(
     try:
         await db.delete(modal_app)
         log.info("Deleted Modal App from database")
-        await _stop_modal_app(app_name, modal_client, settings, app_id)
+        await stop_modal_app(app_name, modal_client, settings, app_id)
         log.info("stopped app on modal")
     except Exception as e:
         await db.rollback()
@@ -509,47 +506,6 @@ async def _deploy_modal_app_helper(
         }
     )
     return result["app_id"]
-
-
-async def _lookup_app_id(
-    app_name: str, modal_client: modal.client._Client, settings: Settings
-) -> str | None:
-    """Look up an app ID from Modal using AppListRequest.
-
-    This is more reliable than AppGetByDeploymentNameRequest as it searches
-    through all apps in the environment.
-    """
-    request = api_pb2.AppListRequest(
-        environment_name=settings.MODAL_ENV,
-    )
-    response = await retry_transient_errors(modal_client.stub.AppList, request)
-
-    for app in response.apps:
-        if app.name == app_name:
-            return app.app_id
-    return None
-
-
-async def _stop_modal_app(
-    app_name: str,
-    modal_client: modal.client._Client,
-    settings: Settings,
-    app_id: str | None = None,
-):
-    if app_id is None:
-        app_id = await _lookup_app_id(app_name, modal_client, settings)
-        if app_id is None:
-            logger.warning(
-                f"Could not find app ID for {app_name}, skipping stop request"
-            )
-            return
-
-    # Stop the app
-    stop_request = api_pb2.AppStopRequest(
-        app_id=app_id,
-        source=api_pb2.APP_STOP_SOURCE_PYTHON_CLIENT,
-    )
-    await retry_transient_errors(modal_client.stub.AppStop, stop_request)
 
 
 async def _handle_omitted_functions(

--- a/garden-backend-service/src/api/tasks/auto_deletion/auto_deletion.py
+++ b/garden-backend-service/src/api/tasks/auto_deletion/auto_deletion.py
@@ -7,7 +7,12 @@ from structlog import get_logger
 from src.config import Settings
 from src.models import Garden, ModalApp
 
-from .utils import delete_marked_entity, mark_entity_for_deletion
+from .utils import (
+    delete_marked_entity,
+    mark_entity_for_deletion,
+    unmark_marked_gardens,
+    unmark_marked_modal_apps,
+)
 
 logger = get_logger(__name__)
 
@@ -37,6 +42,15 @@ async def auto_deletion_background_task(
             num_makred_modal_apps=num_makred_modal_apps,
         )
         log.info("Entities marked for deletion")
+
+        logger.info("Unmarking entities that are no longer deletion candidates...")
+        num_gardens_unmarked = await unmark_marked_gardens(session_maker)
+        num_modal_apps_unmarked = await unmark_marked_modal_apps(session_maker)
+        log = logger.bind(
+            num_gardens_unmarked=num_gardens_unmarked,
+            num_modal_apps_unmarked=num_modal_apps_unmarked,
+        )
+        log.info("Unmarked entites")
 
         logger.info(
             f"Deleting marked entities that were marked more than {deletion_age_limit.days} {'days' if deletion_age_limit.days > 1 else 'day'} ago"

--- a/garden-backend-service/src/api/tasks/auto_deletion/auto_deletion.py
+++ b/garden-backend-service/src/api/tasks/auto_deletion/auto_deletion.py
@@ -18,7 +18,9 @@ logger = get_logger(__name__)
 
 
 async def auto_deletion_background_task(
-    settings: Settings, session_maker: async_sessionmaker
+    settings: Settings,
+    session_maker: async_sessionmaker,
+    modal_client=None,
 ):
     task_interval: timedelta = timedelta(
         seconds=settings.AUTO_DELETION_INTERVAL_SECONDS
@@ -26,6 +28,7 @@ async def auto_deletion_background_task(
     deletion_age_limit: timedelta = timedelta(
         days=settings.AUTO_DELETION_AGE_LIMIT_DAYS
     )
+
     while True:
         logger.info("Auto-deletion task starting sweep...")
         num_marked_gardens = await mark_entity_for_deletion(
@@ -56,10 +59,10 @@ async def auto_deletion_background_task(
             f"Deleting marked entities that were marked more than {deletion_age_limit.days} {'days' if deletion_age_limit.days > 1 else 'day'} ago"
         )
         num_gardens_deleted = await delete_marked_entity(
-            ModalApp, session_maker, deletion_age_limit
+            Garden, session_maker, deletion_age_limit
         )
         num_modal_apps_deleted = await delete_marked_entity(
-            Garden, session_maker, deletion_age_limit
+            ModalApp, session_maker, deletion_age_limit, modal_client
         )
 
         log = logger.bind(

--- a/garden-backend-service/src/api/tasks/auto_deletion/utils.py
+++ b/garden-backend-service/src/api/tasks/auto_deletion/utils.py
@@ -74,3 +74,22 @@ async def unmark_marked_gardens(session_maker) -> int:
                 count += 1
         await db.commit()
     return count
+
+
+async def unmark_marked_modal_apps(session_maker) -> int:
+    # Subquery for all used modal function IDs
+    used_function_ids = select(gardens_modal_functions.c.modal_function_id)
+    # ModalApps where marked_for_deletion is not None and any of their functions are in use
+    stmt = select(ModalApp).where(
+        ModalApp.marked_for_deletion.isnot(None),
+        ModalApp.modal_functions.any(ModalFunction.id.in_(used_function_ids)),
+    )
+    count = 0
+    async with session_maker() as db:
+        results = await db.scalars(stmt)
+        marked_apps = results.all()
+        for app in marked_apps:
+            app.marked_for_deletion = None
+            count += 1
+        await db.commit()
+    return count

--- a/garden-backend-service/src/api/tasks/auto_deletion/utils.py
+++ b/garden-backend-service/src/api/tasks/auto_deletion/utils.py
@@ -34,7 +34,7 @@ async def _update_db_records_with_mark(db: AsyncSession, query: Select):
     now = datetime.now()
     count = 0
     for e in entities_to_mark:
-        # only update the time stamp if
+        # only update the time stamp if there isn't one already
         if e.marked_for_deletion is None:
             e.marked_for_deletion = now
             count += 1
@@ -59,3 +59,18 @@ async def mark_modal_apps_for_deletion(session_maker) -> int:
 
     async with session_maker() as db:
         return await _update_db_records_with_mark(db, stmt)
+
+
+async def unmark_marked_gardens(session_maker) -> int:
+    stmt = select(Garden).where(Garden.marked_for_deletion.isnot(None))
+    count = 0
+    async with session_maker() as db:
+        results = await db.scalars(stmt)
+        marked_gardens = results.all()
+        for g in marked_gardens:
+            # unmark marked gardens that have been published since they were marked
+            if not g.doi_is_draft:
+                g.marked_for_deletion = None
+                count += 1
+        await db.commit()
+    return count

--- a/garden-backend-service/src/api/tasks/auto_deletion/utils.py
+++ b/garden-backend-service/src/api/tasks/auto_deletion/utils.py
@@ -91,14 +91,9 @@ async def mark_gardens_for_deletion(session_maker):
 
 
 async def mark_modal_apps_for_deletion(session_maker) -> int:
-    # First get all modal function IDs that are used in published gardens
-    used_function_ids = (
-        select(gardens_modal_functions.c.modal_function_id)
-        .join(Garden, Garden.id == gardens_modal_functions.c.garden_id)
-        .where(Garden.doi_is_draft.isnot(True))
-    )
+    used_function_ids = await get_function_ids_used_in_published_gardens(session_maker)
 
-    # Then find modal apps where none of their functions are used in the publised gardens
+    # find modal apps where none of their functions are used in the publised gardens
     stmt = select(ModalApp).where(
         ~ModalApp.modal_functions.any(ModalFunction.id.in_(used_function_ids))
     )
@@ -123,9 +118,9 @@ async def unmark_marked_gardens(session_maker) -> int:
 
 
 async def unmark_marked_modal_apps(session_maker) -> int:
-    # Subquery for all used modal function IDs
-    used_function_ids = select(gardens_modal_functions.c.modal_function_id)
-    # ModalApps where marked_for_deletion is not None and any of their functions are in use
+    used_function_ids = await get_function_ids_used_in_published_gardens(session_maker)
+
+    # ModalApps that are marked for deltion and any of their functions are in use by published gardens
     stmt = select(ModalApp).where(
         ModalApp.marked_for_deletion.isnot(None),
         ModalApp.modal_functions.any(ModalFunction.id.in_(used_function_ids)),
@@ -139,3 +134,16 @@ async def unmark_marked_modal_apps(session_maker) -> int:
             count += 1
         await db.commit()
     return count
+
+
+async def get_function_ids_used_in_published_gardens(
+    session_maker: async_sessionmaker,
+) -> list[int]:
+    stmt = (
+        select(gardens_modal_functions.c.modal_function_id)
+        .join(Garden, Garden.id == gardens_modal_functions.c.garden_id)
+        .where(Garden.doi_is_draft.isnot(True), Garden.is_archived.is_(False))
+    )
+    async with session_maker() as db:
+        results = await db.scalars(stmt)
+        return list(results.all())

--- a/garden-backend-service/src/api/tasks/auto_deletion/utils.py
+++ b/garden-backend-service/src/api/tasks/auto_deletion/utils.py
@@ -91,10 +91,14 @@ async def mark_gardens_for_deletion(session_maker):
 
 
 async def mark_modal_apps_for_deletion(session_maker) -> int:
-    # First get all modal function IDs that are used in gardens
-    used_function_ids = select(gardens_modal_functions.c.modal_function_id)
+    # First get all modal function IDs that are used in published gardens
+    used_function_ids = (
+        select(gardens_modal_functions.c.modal_function_id)
+        .join(Garden, Garden.id == gardens_modal_functions.c.garden_id)
+        .where(Garden.doi_is_draft.isnot(True))
+    )
 
-    # Then find modal apps where none of their functions are used
+    # Then find modal apps where none of their functions are used in the publised gardens
     stmt = select(ModalApp).where(
         ~ModalApp.modal_functions.any(ModalFunction.id.in_(used_function_ids))
     )

--- a/garden-backend-service/src/api/tasks/auto_deletion/utils.py
+++ b/garden-backend-service/src/api/tasks/auto_deletion/utils.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import datetime, timedelta
 
 from sqlalchemy import Select, select
@@ -22,10 +21,25 @@ async def mark_entity_for_deletion(
 
 
 async def delete_marked_entity(
-    entity: type[Base], session_maker: async_sessionmaker, interval: timedelta
+    entity: type[Garden | ModalApp],
+    session_maker: async_sessionmaker,
+    interval: timedelta,
 ) -> int:
-    await asyncio.sleep(1)
-    return 0
+    stmt = select(entity).where(entity.marked_for_deletion.isnot(None))
+
+    count = 0
+    async with session_maker() as db:
+        results = await db.scalars(stmt)
+        marked_entities = results.all()
+        count = 0
+        now = datetime.now()
+        for e in marked_entities:
+            if now - e.marked_for_deletion > interval:
+                await db.delete(e)
+                count += 1
+        await db.commit()
+
+    return count
 
 
 async def _update_db_records_with_mark(db: AsyncSession, query: Select):

--- a/garden-backend-service/src/api/tasks/auto_deletion/utils.py
+++ b/garden-backend-service/src/api/tasks/auto_deletion/utils.py
@@ -2,9 +2,14 @@ from datetime import datetime, timedelta
 
 from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from structlog import get_logger
 
+from src.config import get_settings
+from src.modal.utils import stop_modal_app
 from src.models import Base, Garden, ModalApp, ModalFunction
 from src.models._associations import gardens_modal_functions
+
+logger = get_logger(__name__)
 
 
 async def mark_entity_for_deletion(
@@ -24,6 +29,7 @@ async def delete_marked_entity(
     entity: type[Garden | ModalApp],
     session_maker: async_sessionmaker,
     interval: timedelta,
+    modal_client=None,
 ) -> int:
     stmt = select(entity).where(entity.marked_for_deletion.isnot(None))
 
@@ -35,6 +41,28 @@ async def delete_marked_entity(
         now = datetime.now()
         for e in marked_entities:
             if now - e.marked_for_deletion > interval:
+                if entity.__tablename__ == "modal_apps":
+                    # Stop the modal app before deleting it
+                    settings = get_settings()
+                    try:
+                        # Use provided client or skip this step if no client available
+                        if modal_client is not None:
+                            await stop_modal_app(
+                                e.app_name, modal_client, settings, e.modal_app_id
+                            )
+                            logger.info(
+                                f"Stopped modal app {e.app_name} before deletion"
+                            )
+                        else:
+                            logger.warning(
+                                f"No modal client provided, skipping stop for app {e.app_name}"
+                            )
+                            continue
+                    except Exception as ex:
+                        logger.error(
+                            f"Error stopping modal app {e.app_name}: {str(ex)}"
+                        )
+                        continue
                 await db.delete(e)
                 count += 1
         await db.commit()

--- a/garden-backend-service/src/modal/utils.py
+++ b/garden-backend-service/src/modal/utils.py
@@ -174,3 +174,58 @@ async def monitor_modal_deployment(
                 log.error(
                     f"Could not find ModalApp with id {app_id} to update deployment status"
                 )
+
+
+async def lookup_app_id(
+    app_name: str, modal_client: modal.client._Client, settings: Settings
+) -> str | None:
+    """Look up an app ID from Modal using AppListRequest.
+
+    This is more reliable than AppGetByDeploymentNameRequest as it searches
+    through all apps in the environment.
+
+    Args:
+        app_name: Name of the app in Modal
+        modal_client: The Modal client instance
+        settings: Application settings
+
+    Returns:
+        The app ID if found, None otherwise
+    """
+    request = api_pb2.AppListRequest(
+        environment_name=settings.MODAL_ENV,
+    )
+    response = await retry_transient_errors(modal_client.stub.AppList, request)
+
+    for app in response.apps:
+        if app.name == app_name:
+            return app.app_id
+    return None
+
+
+async def stop_modal_app(
+    app_name: str,
+    modal_client: modal.client._Client,
+    settings: Settings,
+    app_id: str | None = None,
+):
+    """Stop a running Modal app.
+
+    Args:
+        app_name: Name of the app in Modal
+        modal_client: The Modal client instance
+        settings: Application settings
+        app_id: Optional app ID (will be looked up if not provided)
+    """
+    if app_id is None:
+        app_id = await lookup_app_id(app_name, modal_client, settings)
+        if app_id is None:
+            log.warning(f"Could not find app ID for {app_name}, skipping stop request")
+            return
+
+    # Stop the app
+    stop_request = api_pb2.AppStopRequest(
+        app_id=app_id,
+        source=api_pb2.APP_STOP_SOURCE_PYTHON_CLIENT,
+    )
+    await retry_transient_errors(modal_client.stub.AppStop, stop_request)

--- a/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_apps.py
@@ -180,7 +180,7 @@ async def test_delete_modal_app(
 
     app_id = post_response["id"]
 
-    mock_stop_app = mocker.patch("src.api.routes.modal.modal_apps._stop_modal_app")
+    mock_stop_app = mocker.patch("src.api.routes.modal.modal_apps.stop_modal_app")
 
     delete_response = await client.delete(f"/modal-apps/{app_id}")
     assert delete_response.status_code == 200

--- a/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
+++ b/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
@@ -1,10 +1,13 @@
-from datetime import datetime
+import asyncio
+from datetime import datetime, timedelta
 
 import pytest
 from faker import Faker
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.tasks.auto_deletion.utils import (
+    delete_marked_entity,
     mark_entity_for_deletion,
     unmark_marked_gardens,
     unmark_marked_modal_apps,
@@ -260,3 +263,91 @@ async def test_unmark_marked_modal_apps_unmarks_used_apps(
         await db.refresh(unused_app)
         assert modal_app.marked_for_deletion is None  # should have been unmarked
         assert unused_app.marked_for_deletion is not None  # should have stayed marked
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_delete_marked_entites_deletes_marked_objects_when_past_limit(
+    async_db_session,
+):
+    async with async_db_session() as db:
+        garden = await create_empty_garden(db)
+        garden.marked_for_deletion = datetime.now()
+        unmarked_garden = await create_empty_garden(db)
+
+        modal_app = await create_modal_app_with_functions(db)
+        modal_app.marked_for_deletion = datetime.now()
+        unmarked_modal_app = await create_modal_app_with_functions(db)
+        await db.commit()
+
+        # set the deletion interval to something short
+        interval = timedelta(milliseconds=100)
+        # wait a bit longer than the interval to make sure the marked obejcts will be deleted
+        await asyncio.sleep(0.2)
+        num_gardens_deleted = await delete_marked_entity(
+            Garden, async_db_session, interval
+        )
+        num_apps_deleted = await delete_marked_entity(
+            ModalApp, async_db_session, interval
+        )
+
+        assert num_gardens_deleted == 1
+        assert num_apps_deleted == 1
+
+        # Query for deleted garden and modal_app by id
+        deleted_garden_result = await db.execute(
+            select(Garden).where(Garden.id == garden.id)
+        )
+        deleted_garden = deleted_garden_result.scalar_one_or_none()
+        deleted_modal_app_result = await db.execute(
+            select(ModalApp).where(ModalApp.id == modal_app.id)
+        )
+        deleted_modal_app = deleted_modal_app_result.scalar_one_or_none()
+
+        # Query for unmarked (should still exist)
+        unmarked_garden_result = await db.execute(
+            select(Garden).where(Garden.id == unmarked_garden.id)
+        )
+        unmarked_garden_db = unmarked_garden_result.scalar_one_or_none()
+        unmarked_modal_app_result = await db.execute(
+            select(ModalApp).where(ModalApp.id == unmarked_modal_app.id)
+        )
+        unmarked_modal_app_db = unmarked_modal_app_result.scalar_one_or_none()
+
+        assert deleted_garden is None
+        assert deleted_modal_app is None
+        assert unmarked_garden_db is not None
+        assert unmarked_modal_app_db is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_delete_marked_entities_skips_if_not_past_interval(async_db_session):
+    async with async_db_session() as db:
+        garden = await create_empty_garden(db)
+        garden.marked_for_deletion = datetime.now()
+        modal_app = await create_modal_app_with_functions(db)
+        modal_app.marked_for_deletion = datetime.now()
+        await db.commit()
+
+        # Use a large interval so the entities are not old enough to be deleted
+        interval = timedelta(hours=1)
+        num_gardens_deleted = await delete_marked_entity(
+            Garden, async_db_session, interval
+        )
+        num_apps_deleted = await delete_marked_entity(
+            ModalApp, async_db_session, interval
+        )
+
+        assert num_gardens_deleted == 0
+        assert num_apps_deleted == 0
+
+        # Confirm both objects still exist
+        garden_result = await db.execute(select(Garden).where(Garden.id == garden.id))
+        garden_db = garden_result.scalar_one_or_none()
+        modal_app_result = await db.execute(
+            select(ModalApp).where(ModalApp.id == modal_app.id)
+        )
+        modal_app_db = modal_app_result.scalar_one_or_none()
+        assert garden_db is not None
+        assert modal_app_db is not None

--- a/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
+++ b/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
@@ -155,20 +155,37 @@ async def test_mark_entities_for_deletion_ignores_in_use_modal_apps(
         # create a couple of modal apps and a garden using one of them
         unused_modal_app = await create_modal_app_with_functions(db)
         used_modal_app = await create_modal_app_with_functions(db)
-        garden = await create_empty_garden(db)
-        garden.modal_functions = used_modal_app.modal_functions
+        unpublished_garden = await create_empty_garden(db)
+        # since the garden is not published, this modal app should get marked
+        unpublished_garden.modal_functions = used_modal_app.modal_functions
+
+        # create a second garden that is publised
+        published_garden = await create_empty_garden(db, draft=False)
+        # add another modal app that is used by the published garden, this one should not get marked
+        pub_modal_app = await create_modal_app_with_functions(db)
+        published_garden.modal_functions = pub_modal_app.modal_functions
+
         await db.commit()
+        await db.refresh(published_garden)
+        await db.refresh(unpublished_garden)
         await db.refresh(used_modal_app)
+        await db.refresh(pub_modal_app)
 
         # run the marking task
         num_marked = await mark_entity_for_deletion(ModalApp, async_db_session)
-        assert num_marked == 1
+        assert num_marked == 2
 
         await db.refresh(unused_modal_app)
         await db.refresh(used_modal_app)
+        await db.refresh(pub_modal_app)
 
         assert unused_modal_app.marked_for_deletion is not None
-        assert used_modal_app.marked_for_deletion is None
+        assert (
+            used_modal_app.marked_for_deletion is not None
+        )  # this one should be marked since it is only used by unpublished gardens
+        assert (
+            pub_modal_app.marked_for_deletion is None
+        )  # we shouldn't mark apps that are used by published gardens
 
 
 @pytest.mark.asyncio

--- a/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
+++ b/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
@@ -1,8 +1,13 @@
+from datetime import datetime
+
 import pytest
 from faker import Faker
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.tasks.auto_deletion.utils import mark_entity_for_deletion
+from src.api.tasks.auto_deletion.utils import (
+    mark_entity_for_deletion,
+    unmark_marked_gardens,
+)
 from src.modal.status import AsyncModalJobStatus
 from src.models import Garden, ModalApp, ModalFunction, User
 
@@ -183,3 +188,43 @@ async def test_mark_entities_for_deletion_is_idempotent(async_db_session):
         assert (
             garden.marked_for_deletion == marked_time
         )  # marked time should not have changed, or been removed
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_unmark_marked_gardens_unmarks_published_gardens(
+    async_db_session,
+):
+    async with async_db_session() as db:
+        # create a published garden
+        garden = await create_empty_garden(db, draft=False)
+        # simulate that it was previously marked for deltion
+        garden.marked_for_deletion = datetime.now()
+        await db.commit()
+
+        # run the unmarking function
+        num_unmarked = await unmark_marked_gardens(async_db_session)
+        assert num_unmarked == 1
+
+        await db.refresh(garden)
+        assert garden.marked_for_deletion is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_unmark_marked_gardens_ignores_unpublished_gardens(
+    async_db_session,
+):
+    async with async_db_session() as db:
+        # create an unpublished garden
+        garden = await create_empty_garden(db)
+        # simulate that it was previously marked for deltion
+        garden.marked_for_deletion = datetime.now()
+        await db.commit()
+
+        # run the unmarking function
+        num_unmarked = await unmark_marked_gardens(async_db_session)
+        assert num_unmarked == 0
+
+        await db.refresh(garden)
+        assert garden.marked_for_deletion is not None

--- a/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
+++ b/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
@@ -271,8 +271,13 @@ async def test_delete_marked_entites_deletes_marked_objects_when_past_limit(
     async_db_session,
     override_get_modal_client_dependency,
     mocker,
-    override_get_settings_dependency,
+    mock_settings,
 ):
+    # Patch the get_settings function to return our mock settings
+    mocker.patch(
+        "src.api.tasks.auto_deletion.utils.get_settings", return_value=mock_settings
+    )
+
     # Directly mock the stop_modal_app function to succeed
     mock_stop_app = mocker.patch("src.api.tasks.auto_deletion.utils.stop_modal_app")
 
@@ -337,8 +342,13 @@ async def test_delete_marked_entities_skips_if_not_past_interval(
     async_db_session,
     override_get_modal_client_dependency,
     mocker,
-    override_get_settings_dependency,
+    mock_settings,
 ):
+    # Patch the get_settings function to return our mock settings
+    mocker.patch(
+        "src.api.tasks.auto_deletion.utils.get_settings", return_value=mock_settings
+    )
+
     # Directly mock the stop_modal_app function again
     mock_stop_app = mocker.patch("src.api.tasks.auto_deletion.utils.stop_modal_app")
 

--- a/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
+++ b/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
@@ -402,3 +402,64 @@ async def test_delete_marked_entities_skips_if_not_past_interval(
         modal_app_db = modal_app_result.scalar_one_or_none()
         assert garden_db is not None
         assert modal_app_db is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_mark_entities_for_deletion_deletes_apps_in_archived_gardens(
+    async_db_session,
+):
+    async with async_db_session() as db:
+        archived_garden = await create_empty_garden(db, draft=False)
+        archived_garden.is_archived = True
+        modal_app = await create_modal_app_with_functions(db)
+        archived_garden.modal_functions = modal_app.modal_functions
+        await db.commit()
+
+        await db.refresh(archived_garden)
+        await db.refresh(modal_app)
+
+        num_marked_apps = await mark_entity_for_deletion(ModalApp, async_db_session)
+        assert num_marked_apps == 1
+
+        await db.refresh(archived_garden)
+        await db.refresh(modal_app)
+        assert modal_app.marked_for_deletion is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_garden_unmarking_function_doesnt_undo_marking_function(
+    async_db_session,
+):
+    """Tests that the garden unmarking function doens't immediately undo the marking function"""
+    async with async_db_session() as db:
+        garden = await create_empty_garden(db)
+
+        num_marked = await mark_entity_for_deletion(Garden, async_db_session)
+        assert num_marked == 1
+
+        num_unmarked = await unmark_marked_gardens(async_db_session)
+        assert num_unmarked == 0
+
+        await db.refresh(garden)
+        assert garden.marked_for_deletion is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_app_unmarking_function_doesnt_undo_marking_function(
+    async_db_session,
+):
+    """Tests that the modal app unmarking function doens't immediately undo the marking function"""
+    async with async_db_session() as db:
+        modal_app = await create_modal_app_with_functions(db)
+
+        num_marked = await mark_entity_for_deletion(ModalApp, async_db_session)
+        assert num_marked == 1
+
+        num_unmarked = await unmark_marked_modal_apps(async_db_session)
+        assert num_unmarked == 0
+
+        await db.refresh(modal_app)
+        assert modal_app.marked_for_deletion is not None

--- a/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
+++ b/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
@@ -268,7 +268,10 @@ async def test_unmark_marked_modal_apps_unmarks_used_apps(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_delete_marked_entites_deletes_marked_objects_when_past_limit(
-    async_db_session, override_get_modal_client_dependency, mocker
+    async_db_session,
+    override_get_modal_client_dependency,
+    mocker,
+    override_get_settings_dependency,
 ):
     # Directly mock the stop_modal_app function to succeed
     mock_stop_app = mocker.patch("src.api.tasks.auto_deletion.utils.stop_modal_app")
@@ -331,7 +334,10 @@ async def test_delete_marked_entites_deletes_marked_objects_when_past_limit(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_delete_marked_entities_skips_if_not_past_interval(
-    async_db_session, override_get_modal_client_dependency, mocker
+    async_db_session,
+    override_get_modal_client_dependency,
+    mocker,
+    override_get_settings_dependency,
 ):
     # Directly mock the stop_modal_app function again
     mock_stop_app = mocker.patch("src.api.tasks.auto_deletion.utils.stop_modal_app")

--- a/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
+++ b/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.tasks.auto_deletion.utils import (
     mark_entity_for_deletion,
     unmark_marked_gardens,
+    unmark_marked_modal_apps,
 )
 from src.modal.status import AsyncModalJobStatus
 from src.models import Garden, ModalApp, ModalFunction, User
@@ -227,4 +228,35 @@ async def test_unmark_marked_gardens_ignores_unpublished_gardens(
         assert num_unmarked == 0
 
         await db.refresh(garden)
+        # make sure the garden is still marked
         assert garden.marked_for_deletion is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_unmark_marked_modal_apps_unmarks_used_apps(
+    async_db_session,
+):
+    async with async_db_session() as db:
+        # create a published garden
+        garden = await create_empty_garden(db, draft=False)
+        # create a modal app
+        modal_app = await create_modal_app_with_functions(db)
+        # simulate that it was marked for deletion at some point
+        modal_app.marked_for_deletion = datetime.now()
+        # it is now in-use by the garden:
+        garden.modal_functions = modal_app.modal_functions
+
+        # create an unused modal app, this one should stay marked
+        unused_app = await create_modal_app_with_functions(db)
+        unused_app.marked_for_deletion = datetime.now()
+        await db.commit()
+
+        # run the unmarking function
+        num_unmarked = await unmark_marked_modal_apps(async_db_session)
+        assert num_unmarked == 1
+
+        await db.refresh(modal_app)
+        await db.refresh(unused_app)
+        assert modal_app.marked_for_deletion is None  # should have been unmarked
+        assert unused_app.marked_for_deletion is not None  # should have stayed marked

--- a/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
+++ b/garden-backend-service/tests/api/tasks/auto_deletion/test_utils.py
@@ -268,15 +268,21 @@ async def test_unmark_marked_modal_apps_unmarks_used_apps(
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_delete_marked_entites_deletes_marked_objects_when_past_limit(
-    async_db_session,
+    async_db_session, override_get_modal_client_dependency, mocker
 ):
+    # Directly mock the stop_modal_app function to succeed
+    mock_stop_app = mocker.patch("src.api.tasks.auto_deletion.utils.stop_modal_app")
+
     async with async_db_session() as db:
         garden = await create_empty_garden(db)
         garden.marked_for_deletion = datetime.now()
         unmarked_garden = await create_empty_garden(db)
 
         modal_app = await create_modal_app_with_functions(db)
+        modal_app.app_name = "test-app"
+        modal_app.modal_app_id = "test-app-id"
         modal_app.marked_for_deletion = datetime.now()
+
         unmarked_modal_app = await create_modal_app_with_functions(db)
         await db.commit()
 
@@ -288,11 +294,13 @@ async def test_delete_marked_entites_deletes_marked_objects_when_past_limit(
             Garden, async_db_session, interval
         )
         num_apps_deleted = await delete_marked_entity(
-            ModalApp, async_db_session, interval
+            ModalApp, async_db_session, interval, override_get_modal_client_dependency
         )
 
         assert num_gardens_deleted == 1
         assert num_apps_deleted == 1
+        # Verify the stop_modal_app function was called
+        assert mock_stop_app.called
 
         # Query for deleted garden and modal_app by id
         deleted_garden_result = await db.execute(
@@ -322,11 +330,19 @@ async def test_delete_marked_entites_deletes_marked_objects_when_past_limit(
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_delete_marked_entities_skips_if_not_past_interval(async_db_session):
+async def test_delete_marked_entities_skips_if_not_past_interval(
+    async_db_session, override_get_modal_client_dependency, mocker
+):
+    # Directly mock the stop_modal_app function again
+    mock_stop_app = mocker.patch("src.api.tasks.auto_deletion.utils.stop_modal_app")
+
     async with async_db_session() as db:
         garden = await create_empty_garden(db)
         garden.marked_for_deletion = datetime.now()
+
         modal_app = await create_modal_app_with_functions(db)
+        modal_app.app_name = "test-app"
+        modal_app.modal_app_id = "test-app-id"
         modal_app.marked_for_deletion = datetime.now()
         await db.commit()
 
@@ -336,11 +352,13 @@ async def test_delete_marked_entities_skips_if_not_past_interval(async_db_sessio
             Garden, async_db_session, interval
         )
         num_apps_deleted = await delete_marked_entity(
-            ModalApp, async_db_session, interval
+            ModalApp, async_db_session, interval, override_get_modal_client_dependency
         )
 
         assert num_gardens_deleted == 0
         assert num_apps_deleted == 0
+        # The stop app function should not be called in this case
+        assert not mock_stop_app.called
 
         # Confirm both objects still exist
         garden_result = await db.execute(select(Garden).where(Garden.id == garden.id))


### PR DESCRIPTION
Auto-deletion part 2
Resolves: #284 

## Overview

Building off #302, this PR adds logic to unmark marked entities if they become non-deletion candidates before the time limit, as well as logic to actually delete entities that are past the time limit.

## Discussion

Nothing too crazy here, just adding to the structure setup in #302.

One extra point of complexity here was stopping modal apps on modal's end before deleting them from our database. I pulled the `stop_modal_app` helper out of the route file and into the modal utils so we can reuse it in the background task.

## Testing

New unit tests that confirm the background task unmarks marked objects correctly, and deletes objects when they have been marked for long enough while making sure we stop modal apps before deleting them from the db.
