### PR TITLE
avoid race condition; save logs/results together

### DIFF
--- a/garden-backend-service/src/api/routes/modal/invocations.py
+++ b/garden-backend-service/src/api/routes/modal/invocations.py
@@ -133,17 +133,15 @@ async def invoke_modal_fn_async(
         user_id=user.id,
         function_id=modal_fn.id,
     )
-    db.add(db_log)
-    await db.commit()  # Commit to get the log ID
-    await db.refresh(db_log)  # Refresh to get the ID
-
     db_result = ModalInvocationResult(
         function_id=modal_fn.id,
         function_call_id=invocation.function_call_id,
         status=AsyncModalJobStatus.PENDING,
-        log_id=db_log.id,
     )
-    db.add(db_result)
+    # establish log-result relationship
+    db_log.result = db_result
+    db_result.log = db_log
+    db.add_all([db_log, db_result])
     await db.commit()
 
     # Add monitoring to background tasks


### PR DESCRIPTION
tried invoking a function many times in a loop and got some surprising (and inconsistent) errors: 
```
Starting relaxation of 20 structures
Request to Garden backend failed. Status code 500. {"detail":"Internal Server Error: (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class 'asyncpg.exceptions.UniqueViolationError'>: duplicate key value violates unique constraint \"modal_invocation_results_pkey\"\nDETAIL:  Key (id)=(50) alr
eady exists.\n[SQL: INSERT INTO modal_invocation_results (function_id, function_call_id, status, error, output, log_id) VALUES ($1::INTEGER, $2::VARCHAR, $3::asyncmodaljobstatus, $4::VARCHAR, $5::BYTEA, $6::INTEGER) RETURNING modal_invocation_results.id]\n[parameters: (491, 'fc-01JTH3YXQ2JCR9M963029
ACC8Y', 'PENDING', None, None, 63)]\n(Background on this error at: https://sqlalche.me/e/20/gkpj)"}
...
Failed to relax wbm-1-19: HTTPError('500 Server Error: Internal Server Error for url: https://api.thegardens.ai/modal-invocations/async')
Request to Garden backend failed. Status code 500. {"detail":"Internal Server Error: (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class 'asyncpg.exceptions.UniqueViolationError'>: duplicate key value violates unique constraint \"modal_invocation_logs_pkey\"\nDETAIL:  Key (id)=(81) alre
y exists.\n[SQL: INSERT INTO modal_invocation_logs (user_id, function_id, date_resolved, estimated_usage) VALUES ($1::INTEGER, $2::INTEGER, $3::TIMESTAMP WITHOUT TIME ZONE, $4::FLOAT) RETURNING modal_invocation_logs.id, modal_invocation_logs.date_invoked]\n[parameters: (1, 491, None, 0.0)]\n(Backg
und on this error at: https://sqlalche.me/e/20/gkpj)"}
```

## Overview

Turns out I introduced a race condition when I split the logs/results table, because I was trying to set the foreign key directly to establish the log:result relationship. By staying at the ORM-level and adding the objects to the session together we should no longer have to worry about this happening.

## Testing

I'm about to!