### PR TITLE
improve handling of modal app validation and deployment errors

### DIFF
--- a/garden-backend-service/src/exceptions/modal.py
+++ b/garden-backend-service/src/exceptions/modal.py
@@ -29,4 +29,9 @@ def handle_modal_exception(request: Request, error: ModalException):
     return JSONResponse(
         status_code=error.status_code,
         content=content,
+        headers={
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "*",
+            "Access-Control-Allow-Headers": "*",
+        },
     )

--- a/garden-backend-service/src/modal/user_file_parsing.py
+++ b/garden-backend-service/src/modal/user_file_parsing.py
@@ -80,6 +80,25 @@ class ModalFileParseResults:
     local_entrypoints: list[ModalLocalEntrypointInfo] = field(default_factory=list)
 
 
+def _validate_module_level_imports(tree: ast.Module) -> None:
+    """Check that there are no module-level imports other than 'import modal'."""
+    for node in tree.body:
+        match node:
+            case ast.Import(names=names):
+                for alias in names:
+                    if alias.name != "modal":
+                        raise ModalException(
+                            detail=f"Module-level import '{alias.name}' is not allowed.",
+                            suggested_fix="Place all imports other than 'import modal' inside function or class scopes.",
+                        )
+            case ast.ImportFrom(module=module_name):
+                if module_name != "modal":
+                    raise ModalException(
+                        detail=f"Module-level import 'from {module_name}' is not allowed.",
+                        suggested_fix="Place all imports other than 'import modal' inside function or class scopes.",
+                    )
+
+
 def parse_modal_file(contents: str) -> ModalFileParseResults:
     """Parse the contents of a user's modal file into image/app/function metadata.
 
@@ -94,6 +113,9 @@ def parse_modal_file(contents: str) -> ModalFileParseResults:
             detail=f"Could not parse Modal file: {str(e)}",
             suggested_fix="Make sure the Modal file is valid Python code.",
         )
+
+    # Validate that there are no disallowed module-level imports
+    _validate_module_level_imports(tree)
 
     images = {}
     apps = {}

--- a/garden-backend-service/tests/api/routes/modal/test_user_file_parsing.py
+++ b/garden-backend-service/tests/api/routes/modal/test_user_file_parsing.py
@@ -1,0 +1,105 @@
+import pytest
+
+from src.exceptions.modal import ModalException
+from src.modal.user_file_parsing import parse_modal_file
+
+
+def test_parse_modal_file_accepts_modal_import():
+    contents = """
+import modal
+
+app = modal.App("my-app")
+
+@app.function()
+def hello():
+    return "Hello World"
+    """
+    result = parse_modal_file(contents)
+    assert len(result.functions) == 1
+    assert result.functions[0].function_name == "hello"
+
+
+def test_parse_modal_file_accepts_from_modal_import():
+    contents = """
+from modal import App, Image
+
+app = App("my-app")
+
+@app.function()
+def hello():
+    return "Hello World"
+    """
+    result = parse_modal_file(contents)
+    assert len(result.functions) == 1
+    assert result.functions[0].function_name == "hello"
+
+
+def test_parse_modal_file_rejects_non_modal_import():
+    contents = """
+import modal
+import numpy as np
+
+app = modal.App("my-app")
+
+@app.function()
+def hello():
+    return "Hello World"
+    """
+    with pytest.raises(ModalException) as excinfo:
+        parse_modal_file(contents)
+    assert "Module-level import 'numpy' is not allowed" in str(excinfo.value.detail)
+
+
+def test_parse_modal_file_rejects_non_modal_from_import():
+    contents = """
+import modal
+from numpy import array
+
+app = modal.App("my-app")
+
+@app.function()
+def hello():
+    return "Hello World"
+    """
+    with pytest.raises(ModalException) as excinfo:
+        parse_modal_file(contents)
+    assert "Module-level import 'from numpy' is not allowed" in str(
+        excinfo.value.detail
+    )
+
+
+def test_parse_modal_file_allows_function_scope_imports():
+    contents = """
+import modal
+
+app = modal.App("my-app")
+
+@app.function()
+def hello():
+    import numpy as np
+    from pandas import DataFrame
+    return "Hello World"
+    """
+    result = parse_modal_file(contents)
+    assert len(result.functions) == 1
+    assert result.functions[0].function_name == "hello"
+
+
+def test_parse_modal_file_allows_class_scope_imports():
+    contents = """
+import modal
+
+app = modal.App("my-app")
+
+@app.cls()
+class MyClass:
+    import numpy as np
+    from pandas import DataFrame
+
+    @modal.method()
+    def method(self):
+        return "Hello World"
+    """
+    result = parse_modal_file(contents)
+    assert len(result.functions) == 1
+    assert result.functions[0].function_name == "MyClass.method"


### PR DESCRIPTION
Resolves: #310 #241 

## Overview

This PR fixes a couple of things, see the #310 comments for details about the CORS issue this fixes. The other fix is an enhancement we have been wanting for a while: catching module level imports during the initial validation pass instead of waiting for modal to throw an error during deployment. This means it shouldn't be possible to get to a state where the error Will found in #310 shows up, but I added some improved handling of `ModalException`s just in case.

## Discussion

The CORS issue is fixed by making sure we include the CORS headers when returning a `JSONResponse` after parsing `ModalException`s.

I added a check during the validation flow to raise an error if we find any module-level imports that are not `import modal`.

## Testing

New unit tests!
Manually!

