### PR TITLE
allow module-level imports from std library

### DIFF
--- a/garden-backend-service/src/modal/user_file_parsing.py
+++ b/garden-backend-service/src/modal/user_file_parsing.py
@@ -1,5 +1,6 @@
 import ast
 import copy
+import sys
 from dataclasses import dataclass, field
 
 import modal
@@ -81,14 +82,15 @@ class ModalFileParseResults:
 
 
 def _validate_module_level_imports(tree: ast.Module) -> None:
-    from .utils import is_stdlib_module  # moved import here to avoid circular import
-
     """Check that there are no module-level imports other than 'import modal' or stdlib imports."""
     for node in tree.body:
         match node:
             case ast.Import(names=names):
                 for alias in names:
-                    if alias.name != "modal" and not is_stdlib_module(alias.name):
+                    if (
+                        alias.name != "modal"
+                        and alias.name not in sys.stdlib_module_names
+                    ):
                         raise ModalException(
                             detail=f"Module-level import '{alias.name}' is not allowed.",
                             suggested_fix="Place all imports other than 'import modal' or stdlib imports inside function or class scopes.",
@@ -96,7 +98,8 @@ def _validate_module_level_imports(tree: ast.Module) -> None:
             case ast.ImportFrom(module=module_name):
                 # Only allow if module_name is 'modal' or a valid stdlib module
                 if module_name is None or (
-                    module_name != "modal" and not is_stdlib_module(module_name)
+                    module_name != "modal"
+                    and module_name not in sys.stdlib_module_names
                 ):
                     raise ModalException(
                         detail=f"Module-level import 'from {module_name}' is not allowed.",

--- a/garden-backend-service/src/modal/user_file_parsing.py
+++ b/garden-backend-service/src/modal/user_file_parsing.py
@@ -81,21 +81,26 @@ class ModalFileParseResults:
 
 
 def _validate_module_level_imports(tree: ast.Module) -> None:
-    """Check that there are no module-level imports other than 'import modal'."""
+    from .utils import is_stdlib_module  # moved import here to avoid circular import
+
+    """Check that there are no module-level imports other than 'import modal' or stdlib imports."""
     for node in tree.body:
         match node:
             case ast.Import(names=names):
                 for alias in names:
-                    if alias.name != "modal":
+                    if alias.name != "modal" and not is_stdlib_module(alias.name):
                         raise ModalException(
                             detail=f"Module-level import '{alias.name}' is not allowed.",
-                            suggested_fix="Place all imports other than 'import modal' inside function or class scopes.",
+                            suggested_fix="Place all imports other than 'import modal' or stdlib imports inside function or class scopes.",
                         )
             case ast.ImportFrom(module=module_name):
-                if module_name != "modal":
+                # Only allow if module_name is 'modal' or a valid stdlib module
+                if module_name is None or (
+                    module_name != "modal" and not is_stdlib_module(module_name)
+                ):
                     raise ModalException(
                         detail=f"Module-level import 'from {module_name}' is not allowed.",
-                        suggested_fix="Place all imports other than 'import modal' inside function or class scopes.",
+                        suggested_fix="Place all imports other than 'import modal' or stdlib imports inside function or class scopes.",
                     )
 
 

--- a/garden-backend-service/src/modal/utils.py
+++ b/garden-backend-service/src/modal/utils.py
@@ -1,5 +1,3 @@
-import importlib.util
-import sysconfig
 from datetime import datetime
 from typing import Awaitable, Callable, Mapping
 
@@ -231,17 +229,3 @@ async def stop_modal_app(
         source=api_pb2.APP_STOP_SOURCE_PYTHON_CLIENT,
     )
     await retry_transient_errors(modal_client.stub.AppStop, stop_request)
-
-
-def is_stdlib_module(module_name: str) -> bool:
-    """Return True if the given module name is part of the Python standard library."""
-    try:
-        spec = importlib.util.find_spec(module_name)
-        if spec is None or spec.origin is None:
-            return False
-        if spec.origin in ("built-in", "frozen"):
-            return True
-        stdlib_path = sysconfig.get_paths()["stdlib"]
-        return spec.origin.startswith(stdlib_path)
-    except Exception:
-        return False

--- a/garden-backend-service/src/modal/utils.py
+++ b/garden-backend-service/src/modal/utils.py
@@ -1,3 +1,5 @@
+import importlib.util
+import sysconfig
 from datetime import datetime
 from typing import Awaitable, Callable, Mapping
 
@@ -229,3 +231,17 @@ async def stop_modal_app(
         source=api_pb2.APP_STOP_SOURCE_PYTHON_CLIENT,
     )
     await retry_transient_errors(modal_client.stub.AppStop, stop_request)
+
+
+def is_stdlib_module(module_name: str) -> bool:
+    """Return True if the given module name is part of the Python standard library."""
+    try:
+        spec = importlib.util.find_spec(module_name)
+        if spec is None or spec.origin is None:
+            return False
+        if spec.origin in ("built-in", "frozen"):
+            return True
+        stdlib_path = sysconfig.get_paths()["stdlib"]
+        return spec.origin.startswith(stdlib_path)
+    except Exception:
+        return False

--- a/garden-backend-service/tests/api/routes/modal/test_user_file_parsing.py
+++ b/garden-backend-service/tests/api/routes/modal/test_user_file_parsing.py
@@ -103,3 +103,53 @@ class MyClass:
     result = parse_modal_file(contents)
     assert len(result.functions) == 1
     assert result.functions[0].function_name == "MyClass.method"
+
+
+def test_parse_modal_file_accepts_stdlib_import():
+    contents = """
+import sys
+import modal
+
+app = modal.App("my-app")
+
+@app.function()
+def hello():
+    return sys.version
+    """
+    result = parse_modal_file(contents)
+    assert len(result.functions) == 1
+    assert result.functions[0].function_name == "hello"
+
+
+def test_parse_modal_file_accepts_stdlib_from_import():
+    contents = """
+from os import path
+import modal
+
+app = modal.App("my-app")
+
+@app.function()
+def hello():
+    return path.join("a", "b")
+    """
+    result = parse_modal_file(contents)
+    assert len(result.functions) == 1
+    assert result.functions[0].function_name == "hello"
+
+
+def test_parse_modal_file_rejects_nonexistent_module():
+    contents = """
+import modal
+import definitelynotamodule
+
+app = modal.App("my-app")
+
+@app.function()
+def hello():
+    return "Hello World"
+    """
+    with pytest.raises(ModalException) as excinfo:
+        parse_modal_file(contents)
+    assert "Module-level import 'definitelynotamodule' is not allowed" in str(
+        excinfo.value.detail
+    )


### PR DESCRIPTION
Related: #310 #241 #318 

## Overview

In #318 we added a check during the initial validation of modal apps to alert users if there are module-level imports. After merging into dev, I discovered that this is blocking imports from the python std lib which is unnecessary. This PR allows imports from the std lib to pass validation.

## Testing

A couple new unit tests!
