### PR TITLE
fix: modal invocations not resolving

### DIFF
--- a/garden-backend-service/src/api/routes/benchmarks.py
+++ b/garden-backend-service/src/api/routes/benchmarks.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
@@ -119,7 +119,7 @@ async def run_benchmark(
         benchmark_id=benchmark.id,
         function_id=function.id,
         task_id=task.id,
-        status=invocation.status,
+        status=AsyncModalJobStatus(invocation.status),
     )
     return response
 
@@ -128,6 +128,7 @@ async def run_benchmark(
 async def get_results_for_benchmark_task(
     benchmark_id: int,
     task_id: int,
+    include_failed: bool = Query(default=False),
     modal_client: Client = Depends(get_modal_client),
     db: AsyncSession = Depends(get_db_session),
 ):
@@ -160,7 +161,11 @@ async def get_results_for_benchmark_task(
     benchmark_runs_with_date = results.all()
 
     benchmark_results = await _get_results_for_runs(
-        benchmark_runs_with_date, db, modal_client, logger
+        benchmark_runs_with_date,
+        db,
+        modal_client,
+        logger,
+        include_failed,
     )
     return benchmark_results
 
@@ -212,6 +217,7 @@ async def _get_results_for_runs(
     db: AsyncSession,
     modal_client: Client,
     logger,
+    include_failed: bool,
 ) -> list[BenchmarkResult]:
     """"""
     results = []
@@ -230,15 +236,26 @@ async def _get_results_for_runs(
                 )
                 continue
 
-            # Initialize result to None
-            invocation_result = None
-
             # The status is already an AsyncModalJobStatus enum value
             status = invocation_output.get("status", AsyncModalJobStatus.PENDING)
 
-            # Only try to deserialize if we have a completed run with a result
+            # Filter based on status
+            status_filters = [AsyncModalJobStatus.DONE]
+            if include_failed:
+                status_filters.append(AsyncModalJobStatus.ERROR)
+                status_filters.append(AsyncModalJobStatus.TIMED_OUT)
+
+            # Skip if status doesn't match our filters
+            if status not in status_filters:
+                continue
+
+            # Initialize result and error to None
+            invocation_result = None
+            error = None
+
+            # Handle successful runs with results
             if (
-                status is AsyncModalJobStatus.DONE
+                status == AsyncModalJobStatus.DONE
                 and "result" in invocation_output
                 and invocation_output["result"]
             ):
@@ -246,6 +263,8 @@ async def _get_results_for_runs(
                     invocation_result = deserialize(
                         invocation_output["result"].data, modal_client
                     )
+                    # Get exception from result if it exists
+                    error = invocation_output["result"].exception or None
                 except Exception as e:
                     logger.error(
                         "Failed to deserialize invocation result",
@@ -253,6 +272,12 @@ async def _get_results_for_runs(
                         invocation_id=benchmark_run.invocation_id,
                         error=str(e),
                     )
+                    # For successful runs that failed to deserialize, treat as error
+                    error = f"Failed to deserialize result: {str(e)}"
+
+            # Handle failed runs
+            elif status in [AsyncModalJobStatus.ERROR, AsyncModalJobStatus.TIMED_OUT]:
+                error = invocation_output.get("error")
 
             # Create the benchmark result
             result = BenchmarkResult(
@@ -262,6 +287,7 @@ async def _get_results_for_runs(
                 status=status,
                 result=invocation_result,
                 date_invoked=date_invoked,
+                error=error,
             )
             results.append(result)
         except Exception as e:

--- a/garden-backend-service/src/api/routes/modal/invocations.py
+++ b/garden-backend-service/src/api/routes/modal/invocations.py
@@ -145,7 +145,7 @@ async def invoke_modal_fn_async(
 
     # Add monitoring to background tasks
     background_tasks.add_task(
-        monitor_modal_invocation, invocation, db_result, modal_client, settings
+        monitor_modal_invocation, invocation, db_result.id, modal_client, settings
     )
 
     # Return the invocation ID immediately

--- a/garden-backend-service/src/modal/utils.py
+++ b/garden-backend-service/src/modal/utils.py
@@ -98,7 +98,9 @@ async def monitor_modal_invocation(
         result = await ModalInvocationResult.get(session, id=db_result_id)
     if result is None:
         # We don't have this result in the db, bail
-        log.info(f"modal invocation result with id {db_result.id} not found in database")
+        log.info(
+            f"modal invocation result with id {db_result_id} not found in database"
+        )
         return
 
     try:

--- a/garden-backend-service/src/modal/utils.py
+++ b/garden-backend-service/src/modal/utils.py
@@ -50,9 +50,9 @@ async def _process_modal_invocation(
     invocation: modal._functions._Invocation,
     timeout_seconds: float,
 ) -> ModalInvocationResult:
-    """Parse ouptut and errors from raw modal invocations.
+    """Parse output and errors from raw modal invocations.
 
-    Tell modal to cancel the invocation if it has been longer than
+    Tell modal to cancel the invocation if it has been longer than timeout_seconds
     """
     # create result to hold the parsed output data
     result = ModalInvocationResult(status=AsyncModalJobStatus.PENDING)
@@ -98,7 +98,7 @@ async def monitor_modal_invocation(
         result = await ModalInvocationResult.get(session, id=db_result_id)
     if result is None:
         # We don't have this result in the db, bail
-        log.info("modal invocation result with id {db_result.id} not found in database")
+        log.info(f"modal invocation result with id {db_result.id} not found in database")
         return
 
     try:

--- a/garden-backend-service/src/modal/utils.py
+++ b/garden-backend-service/src/modal/utils.py
@@ -46,6 +46,35 @@ async def resolve_modal_invocation(
         raise ValueError(f"No Modal Function with id: {id} found!")
 
 
+async def _process_invocation_completion(
+    invocation: modal._functions._Invocation,
+    result: ModalInvocationResult,
+    client: modal.Client,
+    session: AsyncSession,
+    settings: Settings,
+):
+    """Process the completion of a modal invocation and handle outputs, timeouts, and errors."""
+    # Try and get the invocation outputs
+    outputs_response = await invocation.pop_function_call_outputs(
+        timeout=settings.MODAL_TIMEOUT_SECONDS,
+        clear_on_success=True,
+    )
+    # If we have outputs, the invocation suceeded, write the outputs to the DB
+    if outputs_response.outputs:
+        result.output = outputs_response.outputs[0].SerializeToString()
+        await resolve_modal_invocation(result, AsyncModalJobStatus.DONE, session)
+        await session.commit()
+        return
+    # If there are no outputs and unfinished inputs the invocation has timed out, cancel it!
+    if outputs_response.num_unfinished_inputs > 0:
+        await cancel_modal_invocation(result, client)
+        result.error = "Timed out!"
+        await resolve_modal_invocation(result, AsyncModalJobStatus.TIMED_OUT, session)
+        raise ModalException("Modal Invocation Timed out!", status_code=408)
+    else:
+        raise ValueError(f"{outputs_response}")
+
+
 async def monitor_modal_invocation(
     invocation: modal._functions._Invocation,
     db_result: ModalInvocationResult,
@@ -56,29 +85,9 @@ async def monitor_modal_invocation(
     async with session_maker() as session:
         if result := await ModalInvocationResult.get(session, id=db_result.id):
             try:
-                # Try and get the invocation outputs
-                outputs_response = await invocation.pop_function_call_outputs(
-                    timeout=settings.MODAL_TIMEOUT_SECONDS,
-                    clear_on_success=True,
+                await _process_invocation_completion(
+                    invocation, result, client, session, settings
                 )
-                # If we have outputs, the invocation suceeded, write the outputs to the DB
-                if outputs_response.outputs:
-                    result.output = outputs_response.outputs[0].SerializeToString()
-                    await resolve_modal_invocation(
-                        result, AsyncModalJobStatus.DONE, session
-                    )
-                    await session.commit()
-                    return
-                # If there are no outputs and unfinished inputs the invocation has timed out, cancel it!
-                if outputs_response.num_unfinished_inputs > 0:
-                    await cancel_modal_invocation(result, client)
-                    result.error = "Timed out!"
-                    await resolve_modal_invocation(
-                        result, AsyncModalJobStatus.TIMED_OUT, session
-                    )
-                    raise ModalException("Modal Invocation Timed out!", status_code=408)
-                else:
-                    raise ValueError(f"{outputs_response}")
             except ModalException:
                 # Reraise the exception if we already wrapped it in a ModalException
                 raise

--- a/garden-backend-service/src/modal/utils.py
+++ b/garden-backend-service/src/modal/utils.py
@@ -54,30 +54,34 @@ async def _process_modal_invocation(
 
     Tell modal to cancel the invocation if it has been longer than
     """
-    # Try and get the invocation outputs
+    # create result to hold the parsed output data
+    result = ModalInvocationResult(status=AsyncModalJobStatus.PENDING)
+
+    # poll for the invocation outputs
     outputs_response = await invocation.pop_function_call_outputs(
         timeout=timeout_seconds,
         clear_on_success=True,
     )
-    result = ModalInvocationResult(status=AsyncModalJobStatus.PENDING)
 
-    # If we have outputs, the invocation suceeded
+    # parse the outputs if we got any
     if outputs_response.outputs:
-        log.debug("Modal invocation succeeded")
+        if outputs_response.outputs[0].result.exception:
+            log.info("Modal invocation failed at runtime!")
+            result.status = AsyncModalJobStatus.ERROR
+            result.error = outputs_response.outputs[0].result.exception
+        else:
+            result.status = AsyncModalJobStatus.DONE
         result.output = outputs_response.outputs[0].SerializeToString()
-        result.status = AsyncModalJobStatus.DONE
-
-    # If there are no outputs and unfinished inputs the invocation has timed out, cancel it!
+    # If there are no outputs and unfinished inputs the invocation has timed out
     elif outputs_response.num_unfinished_inputs > 0:
-        log.debug("Modal invocation timed out")
         result.status = AsyncModalJobStatus.TIMED_OUT
         result.error = "Function Timed out!"
 
+    # Something else went wrong if the status is still pending
     if result.status == AsyncModalJobStatus.PENDING:
-        log.debug("Something else went wrong!")
-        # Something else wernt wrong
         result.error = f"{outputs_response}"
         result.status = AsyncModalJobStatus.ERROR
+
     return result
 
 

--- a/garden-backend-service/src/modal/utils.py
+++ b/garden-backend-service/src/modal/utils.py
@@ -46,57 +46,86 @@ async def resolve_modal_invocation(
         raise ValueError(f"No Modal Function with id: {id} found!")
 
 
-async def _process_invocation_completion(
+async def _process_modal_invocation(
     invocation: modal._functions._Invocation,
-    result: ModalInvocationResult,
-    client: modal.Client,
-    session: AsyncSession,
-    settings: Settings,
-):
-    """Process the completion of a modal invocation and handle outputs, timeouts, and errors."""
+    timeout_seconds: float,
+) -> ModalInvocationResult:
+    """Parse ouptut and errors from raw modal invocations.
+
+    Tell modal to cancel the invocation if it has been longer than
+    """
     # Try and get the invocation outputs
     outputs_response = await invocation.pop_function_call_outputs(
-        timeout=settings.MODAL_TIMEOUT_SECONDS,
+        timeout=timeout_seconds,
         clear_on_success=True,
     )
-    # If we have outputs, the invocation suceeded, write the outputs to the DB
+    result = ModalInvocationResult(status=AsyncModalJobStatus.PENDING)
+
+    # If we have outputs, the invocation suceeded
     if outputs_response.outputs:
+        log.debug("Modal invocation succeeded")
         result.output = outputs_response.outputs[0].SerializeToString()
-        await resolve_modal_invocation(result, AsyncModalJobStatus.DONE, session)
-        await session.commit()
-        return
+        result.status = AsyncModalJobStatus.DONE
+
     # If there are no outputs and unfinished inputs the invocation has timed out, cancel it!
-    if outputs_response.num_unfinished_inputs > 0:
-        await cancel_modal_invocation(result, client)
-        result.error = "Timed out!"
-        await resolve_modal_invocation(result, AsyncModalJobStatus.TIMED_OUT, session)
-        raise ModalException("Modal Invocation Timed out!", status_code=408)
-    else:
-        raise ValueError(f"{outputs_response}")
+    elif outputs_response.num_unfinished_inputs > 0:
+        log.debug("Modal invocation timed out")
+        result.status = AsyncModalJobStatus.TIMED_OUT
+        result.error = "Function Timed out!"
+
+    if result.status == AsyncModalJobStatus.PENDING:
+        log.debug("Something else went wrong!")
+        # Something else wernt wrong
+        result.error = f"{outputs_response}"
+        result.status = AsyncModalJobStatus.ERROR
+    return result
 
 
 async def monitor_modal_invocation(
     invocation: modal._functions._Invocation,
-    db_result: ModalInvocationResult,
+    db_result_id: int,
     client: modal.Client,
     settings: Settings,
 ):
+    """Background task for asynchronously polling modal for invocation outputs/errors"""
+
     session_maker = await get_db_session_maker(settings=settings)
     async with session_maker() as session:
-        if result := await ModalInvocationResult.get(session, id=db_result.id):
-            try:
-                await _process_invocation_completion(
-                    invocation, result, client, session, settings
-                )
-            except ModalException:
-                # Reraise the exception if we already wrapped it in a ModalException
-                raise
-            except Exception as e:
-                # Otherwise, write the error to the DB
-                result.error = str(e)
-                status = AsyncModalJobStatus.ERROR
-                await resolve_modal_invocation(result, status, session)
-                await session.commit()
+        result = await ModalInvocationResult.get(session, id=db_result_id)
+    if result is None:
+        # We don't have this result in the db, bail
+        log.info("modal invocation result with id {db_result.id} not found in database")
+        return
+
+    try:
+        # poll for and parse the outputs from modal,
+        log.info(f"Polling modal for invocation results for invocation {db_result_id}")
+        processed_result = await _process_modal_invocation(
+            invocation, settings.MODAL_TIMEOUT_SECONDS
+        )
+
+        # update the existing record with parsed info
+        result.status = processed_result.status
+        result.output = processed_result.output
+        result.error = processed_result.error
+        result.log.date_resolved = datetime.now()
+
+        if result.status in [AsyncModalJobStatus.ERROR, AsyncModalJobStatus.TIMED_OUT]:
+            # send a request to cancel the invocation on modal's end, just to be safe
+            await cancel_modal_invocation(result, client)
+
+    except Exception as e:
+        log.error(f"Getting outputs from modal failed: {e}")
+        result.error = str(e)
+        result.status = AsyncModalJobStatus.ERROR
+
+    try:
+        # write any updates to the db
+        async with session_maker() as session:
+            session.add(result)
+            await session.commit()
+    except Exception as e:
+        log.error(f"Failed to update modal invocation result: {e}")
 
 
 async def monitor_modal_deployment(


### PR DESCRIPTION
Fixes: #320

## Overview

This PR fixes an issue with the `monitor_modal_invocation` background task where sometimes a failed function invocation wouldn't get caught and was marked 'pending' forever.

I added a query param to the get route for benchmark results called `include_failed` to get better visibility into failed benchmark runs on the FE. My intention is to keep failed runs out of view of users, but since garden devs will likely need to do some debugging when running benchmarks, having this will be nice. I added it in this PR because I needed it to manually test and make sure we were catching failed benchmark invocations correctly, which is where we first saw this issue.

## Discussion

Pretty hefty refactor of the background task. The major highlights:

- restructured the main task `monitor_modal_invocation` to be more readable and have better handling of database sessions
- pulled the logic that parses raw invocation output from modal into a  (mostly) pure helper function
- Make the task handle all errors that might happen during the task to keep errors from propagating up and killing the server

While refactoring the raw invocation processing, I realized I had made a false assumption about hanlding outputs and errors from modal in my first pass. Specifically, I was assuming if we had any outputs at all from `pop_function_call_outputs` that the invocation succeeded and marked it as 'done'. 

Turns out, when an invocation has a runtime error we still get outputs (containing error info), but also get an exception field we can use to report what when wrong. I beefed up the handling to make sure we correctly determine whether the invocation actually failed, but still has outputs, and capture the exception information in the database.

I was also assuming we would always get a 'result' field in the output response, and that is not always the case. I think this was the root cause of forever 'pending' issue.

## Testing

The load test `test_concurrent_modal_invocations` in `tests/load_test.py` covers most of the background task logic.

I tested manually with some functions that cause errors and couldn't trigger a forever  'pending' state. Once this is in dev, I want to run some tests of Owen's matbench benchmark since that is where we first noticed #320 
