### PR TITLE
fix: modal image detection

### DIFF
--- a/garden-backend-service/src/api/routes/modal/modal_file_metadata.py
+++ b/garden-backend-service/src/api/routes/modal/modal_file_metadata.py
@@ -15,8 +15,8 @@ from src.exceptions.modal import ModalException
 from src.modal.user_file_parsing import (
     ModalFileParseResults,
     ModalLocalEntrypointInfo,
+    _image_default,
     parse_modal_file,
-    _image_default
 )
 from src.models import User
 
@@ -64,7 +64,7 @@ async def parse_modal_file_metadata(
     if results.images:
         base_image = results.images[0].base_image
     else:
-        base_image = _image_default().base_image # If no images used resort to default
+        base_image = _image_default().base_image
 
     response = ModalFileMetadataResponse(
         app_name=app_info.app_name,

--- a/garden-backend-service/src/api/routes/modal/modal_file_metadata.py
+++ b/garden-backend-service/src/api/routes/modal/modal_file_metadata.py
@@ -16,6 +16,7 @@ from src.modal.user_file_parsing import (
     ModalFileParseResults,
     ModalLocalEntrypointInfo,
     parse_modal_file,
+    _image_default
 )
 from src.models import User
 
@@ -60,9 +61,14 @@ async def parse_modal_file_metadata(
 
     app_info = results.apps[0]
 
+    if results.images:
+        base_image = results.images[0].base_image
+    else:
+        base_image = _image_default().base_image # If no images used resort to default
+
     response = ModalFileMetadataResponse(
         app_name=app_info.app_name,
-        base_image_name=app_info.image.base_image,
+        base_image_name=base_image,
         file_contents=request.file_contents,
         modal_functions=function_metas,
         requirements=app_info.image.pip_requirements,


### PR DESCRIPTION
Fixes: #309 

## Overview

This PR is a targeted quick fix for Modal app image detection. Previously when adding a Modal file to garden with an image such as `modal.Image.debian_slim(python_version="3.11")` the correct version of Python was not caught and would default to 3.12.6. 

This was due to `parse_modal_file_metadata` using the app level schema to grab the base image, which was not being correctly defined and resorting to `_image_default`. This targeted fix checks if any images were defined, if so, it uses the first image's base_image. If no images were detected, `_image_default` is used which produces the Python 3.12.6 that was always seen earlier.

## Discussion

This is a quick fix specifically for issue #309 but does not address an underlying issue. If a Modal app has multiple images used across different functions then having a base image for the whole app could cause issues (#322).

## Testing

I was able to upload a garden with different versions of Python and see those get caught by the fix. I uploaded a Modal file with image `modal.Image.debian_slim(python_version="3.10")` and saw these results: 
![image](https://github.com/user-attachments/assets/1f78d7c2-b3cf-49ff-8a5c-90c82b8fb829)

