### PR TITLE
Add invocation count to function responses

### DIFF
--- a/garden-backend-service/src/api/routes/modal/modal_apps.py
+++ b/garden-backend-service/src/api/routes/modal/modal_apps.py
@@ -67,7 +67,7 @@ async def add_modal_app(
     )
     modal_app_db_model.modal_app_id = app_id
     await db.commit()
-
+    await db.refresh(modal_app_db_model)
     return modal_app_db_model
 
 
@@ -105,7 +105,7 @@ async def add_modal_app_async(
         modal_app_db_model.id,
         settings,
     )
-
+    await db.refresh(modal_app_db_model)
     return modal_app_db_model
 
 
@@ -146,7 +146,7 @@ async def redeploy_modal_app(
         modal_app.id,
         settings,
     )
-
+    await db.refresh(modal_app)
     return modal_app
 
 

--- a/garden-backend-service/src/api/routes/modal/modal_functions.py
+++ b/garden-backend-service/src/api/routes/modal/modal_functions.py
@@ -57,7 +57,7 @@ async def get_modal_functions(
     draft: bool | None = Query(None),
     year: str | None = Query(None),
     limit: int = Query(50, le=100),
-) -> list[ModalFunction]:
+) -> list[ModalFunctionMetadataResponse]:
     """Fetch multiple modal functions according to query parameters."""
     stmt = select(ModalFunction)
 

--- a/garden-backend-service/src/api/routes/modal/modal_functions.py
+++ b/garden-backend-service/src/api/routes/modal/modal_functions.py
@@ -41,7 +41,11 @@ async def get_modal_function(
     return modal_function
 
 
-@router.get("", status_code=status.HTTP_200_OK)
+@router.get(
+    "",
+    status_code=status.HTTP_200_OK,
+    response_model=list[ModalFunctionMetadataResponse],
+)
 async def get_modal_functions(
     db: AsyncSession = Depends(get_db_session),
     *,
@@ -53,7 +57,7 @@ async def get_modal_functions(
     draft: bool | None = Query(None),
     year: str | None = Query(None),
     limit: int = Query(50, le=100),
-) -> list[ModalFunctionMetadataResponse]:
+) -> list[ModalFunction]:
     """Fetch multiple modal functions according to query parameters."""
     stmt = select(ModalFunction)
 
@@ -80,7 +84,7 @@ async def get_modal_functions(
         stmt = stmt.where(ModalFunction.year == year)
 
     result = await db.scalars(stmt.limit(limit))
-    return result.all()
+    return list(result.all())
 
 
 @router.patch("/{id}", response_model=ModalFunctionMetadataResponse)

--- a/garden-backend-service/src/api/schemas/modal/modal_function.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_function.py
@@ -15,6 +15,9 @@ class ModalFunctionMetadata(CommonFunctionMetadata):
     # modal supports conda requirements but entrypoints don't
     conda_requirements: list[str] = Field(default_factory=list)
     example_usage: str = ""
+    num_invocations: int = Field(
+        default=0, description="The number of times this function has been invoked"
+    )
 
 
 class ModalFunctionMetadataResponse(ModalFunctionMetadata):

--- a/garden-backend-service/src/api/schemas/modal/modal_function.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_function.py
@@ -15,9 +15,6 @@ class ModalFunctionMetadata(CommonFunctionMetadata):
     # modal supports conda requirements but entrypoints don't
     conda_requirements: list[str] = Field(default_factory=list)
     example_usage: str = ""
-    num_invocations: int = Field(
-        default=0, description="The number of times this function has been invoked"
-    )
 
 
 class ModalFunctionMetadataResponse(ModalFunctionMetadata):
@@ -26,6 +23,10 @@ class ModalFunctionMetadataResponse(ModalFunctionMetadata):
     owner: str = Field(validation_alias=AliasPath("owner", "name"))
     owner_identity_id: UUID = Field(validation_alias=AliasPath("owner", "identity_id"))
     hardware_spec: dict
+    num_invocations: int = Field(
+        default_factory=lambda: 0,
+        description="The number of times this function has been invoked",
+    )
 
 
 class ModalFunctionPatchRequest(CommonFunctionPatchRequest):

--- a/garden-backend-service/src/models/modal/modal_function.py
+++ b/garden-backend-service/src/models/modal/modal_function.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from src.models.base import Base
 
 if TYPE_CHECKING:
+    from src.models.modal.invocations import ModalInvocationLog
     from src.models.modal.modal_app import ModalApp
     from src.models.user import User
 
@@ -53,6 +54,16 @@ class ModalFunction(Base):
     modal_app: Mapped[ModalApp] = relationship(
         ModalApp, back_populates="modal_functions", lazy="selectin"
     )
+
+    invocation_logs: Mapped[list["ModalInvocationLog"]] = relationship(
+        "ModalInvocationLog",
+        back_populates="function",
+        lazy="selectin",
+    )
+
+    @property
+    def num_invocations(self) -> int:
+        return len(self.invocation_logs)
 
     @property
     def owner(self) -> User:

--- a/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
@@ -1,3 +1,5 @@
+import base64
+
 import pytest
 
 from tests.utils import post_modal_app
@@ -135,3 +137,55 @@ async def test_patch_modal_function_partial_update(
     assert patch_response.status_code == 200
     patched_data = patch_response.json()
     assert set(patched_data["tags"]) == set(["Some", "New", "Tags"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_modal_function_num_invocations(
+    client,
+    mock_db_session,
+    mock_modal_publisher_auth_state,
+    mock_modal_app_create_request_one_function,
+    override_sandboxed_functions,
+    mocker,
+):
+    # Create a modal app which adds a modal function
+    create_app_response = await post_modal_app(
+        client, mock_modal_app_create_request_one_function
+    )
+    created_function_id = create_app_response["modal_functions"][0]["id"]
+
+    # "Invoke" the function a few times
+    # Mock the parts of the invocation that interact with Modal
+    # to avoid external calls
+    mock_function_obj = mocker.MagicMock()
+    mock_function_obj.object_id = "mock_function_id"
+    mock_invocation_obj = mocker.AsyncMock()
+    mock_invocation_obj.function_call_id = "mock_call_id"
+
+    mocker.patch(
+        "src.api.routes.modal.invocations._fetch_modal_function",
+        return_value=mock_function_obj,
+    )
+    mocker.patch(
+        "src.api.routes.modal.invocations._create_invocation",
+        return_value=mock_invocation_obj,
+    )
+    mocker.patch("src.api.routes.modal.invocations.monitor_modal_invocation")
+
+    num_test_invocations = 3
+    for _ in range(num_test_invocations):
+        invocation_payload = {
+            "function_id": created_function_id,
+            "args_kwargs_serialized": base64.b64encode(b"test_payload").decode("utf-8"),
+        }
+        invoke_response = await client.post(
+            "/modal-invocations/async", json=invocation_payload
+        )
+        assert invoke_response.status_code == 200
+
+    # Get the modal function and check num_invocations
+    get_function_response = await client.get(f"/modal-functions/{created_function_id}")
+    assert get_function_response.status_code == 200
+    get_function_data = get_function_response.json()
+    assert get_function_data["num_invocations"] == num_test_invocations

--- a/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
+++ b/garden-backend-service/tests/api/routes/modal/test_modal_functions.py
@@ -25,6 +25,7 @@ async def test_get_modal_function(
         == mock_modal_app_create_request_one_function["modal_functions"][0]["title"]
     )
     assert get_function_data["hardware_spec"] is not None
+    assert get_function_data["num_invocations"] is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Resolves: #325 

## Overview

This PR add a `num_invocations` field to function metadata responses.

## Discussion

This is achieved by adding a new property to the `ModalFunciton` model that counts the number of `ModalInvocationLogs` that have the same function id.

## Testing

New unit test, manually with the frontend
