### PR TITLE
Owen/fix base image parse

### DIFF
--- a/garden-backend-service/src/api/routes/modal/modal_file_metadata.py
+++ b/garden-backend-service/src/api/routes/modal/modal_file_metadata.py
@@ -15,7 +15,6 @@ from src.exceptions.modal import ModalException
 from src.modal.user_file_parsing import (
     ModalFileParseResults,
     ModalLocalEntrypointInfo,
-    _image_default,
     parse_modal_file,
 )
 from src.models import User
@@ -61,14 +60,9 @@ async def parse_modal_file_metadata(
 
     app_info = results.apps[0]
 
-    if results.images:
-        base_image = results.images[0].base_image
-    else:
-        base_image = _image_default().base_image
-
     response = ModalFileMetadataResponse(
         app_name=app_info.app_name,
-        base_image_name=base_image,
+        base_image_name=app_info.image.base_image,
         file_contents=request.file_contents,
         modal_functions=function_metas,
         requirements=app_info.image.pip_requirements,

--- a/garden-backend-service/src/api/schemas/modal/modal_function.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_function.py
@@ -20,7 +20,7 @@ class ModalFunctionMetadata(CommonFunctionMetadata):
 class ModalFunctionMetadataResponse(ModalFunctionMetadata):
     id: int = Field(..., description="The unique identifier for the modal function")
     modal_app_id: int
-    owner: str = Field(validation_alias=AliasPath("owner", "name"))
+    owner: str = Field("", validation_alias=AliasPath("owner", "name"))
     owner_identity_id: UUID = Field(validation_alias=AliasPath("owner", "identity_id"))
     hardware_spec: dict
     num_invocations: int = Field(

--- a/garden-backend-service/src/modal/user_file_parsing.py
+++ b/garden-backend-service/src/modal/user_file_parsing.py
@@ -170,6 +170,12 @@ def parse_modal_file(contents: str) -> ModalFileParseResults:
             suggested_fix="Make sure Modal App variable is named 'app'. e.g. 'app =  modal.App(...)'",
         )
 
+    if images:
+        # if we parsed any explicitly defined images, overwrite app's default
+        # with the first one we found
+        image = list(images.values())[0]
+        apps["app"].image = image
+
     return ModalFileParseResults(
         images=list(images.values()),
         apps=list(apps.values()),


### PR DESCRIPTION
fixes #334 

## Overview

This just moves the logic from @loganalt9's recent PR from the route function to inside the `parse_modal_file` helper function, so that both the validation step and the final deployment step will find the same image (and the correct one now, too). 

## Discussion
There are some opportunities for us to clean up the file validation logic now that we know more about the files we can actually deploy with modal -- for instance, we could assume/enforce that there only is one app per file to simplify some of the parsing logic. That said, I decided not to be a good boyscout here because I don't think it'll slow us down next time we need to touch the file validation logic. 

## Testing

Manual smoke test by deploying an app locally 