### PR TITLE
minimal SSE route for sanity check

### DIFF
--- a/garden-backend-service/src/main.py
+++ b/garden-backend-service/src/main.py
@@ -1,10 +1,12 @@
 import asyncio
 import os
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 from structlog import get_logger
 
 import src.logging  # noqa  # import to ensure logger is configured
@@ -110,3 +112,13 @@ app.mount("/mcp", mcp.sse_app())
 @app.get("/")
 async def greet_world():
     return {"Hello there": "You must be World"}
+
+
+@app.get("/test-sse")
+async def sse_sanity_check():
+    def gen():
+        for i in range(100):
+            yield f"sse test message {i}"
+            time.sleep(1)
+
+    return StreamingResponse(gen(), media_type="text/event-stream")


### PR DESCRIPTION
🤠 cowboy PR! 🤠  

claude dot ai is having difficulty connecting to the MCP server when pointed at our deployment on lightsail, but when pointed at a local dev server via an ngrok url claude can connect just fine. 

I have a feeling this is a problem with the lightsail default load balancer being picky, and this is the minimal route I'd need to confirm my suspicion. 

## Discussion

I hope this is wrong, because we can't configure the lightsail load balancer for a container service (afaik) so we would need a totally different deployment for the MCP server than lightsail. 


## Testing

about to!