### PR TITLE
add middleware to keep MCP connection alive

### DIFF
--- a/garden-backend-service/src/main.py
+++ b/garden-backend-service/src/main.py
@@ -34,6 +34,7 @@ from src.middleware.logging import (
     AddRequestIDMiddleware,
     ErrorHandlingMiddleware,
     HeaderLoggingMiddleware,
+    MCPKeepAliveMiddleware,
     ProcessTimeMiddleware,
 )
 
@@ -93,6 +94,7 @@ app.add_middleware(ErrorHandlingMiddleware)
 app.add_middleware(ProcessTimeMiddleware)
 app.add_middleware(AddRequestIDMiddleware)
 app.add_middleware(HeaderLoggingMiddleware)
+app.add_middleware(MCPKeepAliveMiddleware)
 
 app.include_router(greet.router)
 app.include_router(docker_push_token.router)

--- a/garden-backend-service/src/middleware/logging.py
+++ b/garden-backend-service/src/middleware/logging.py
@@ -163,3 +163,29 @@ class HeaderLoggingMiddleware:
         )
 
         await self.app(scope, receive, send)
+
+
+class MCPKeepAliveMiddleware:
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        if scope["type"] == "http" and scope["path"].startswith("/mcp"):
+            # Add keepalive headers for MCP endpoints
+            async def send_wrapper(message):
+                if message["type"] == "http.response.start":
+                    headers = list(message.get("headers", []))
+
+                    headers.extend(
+                        [
+                            [b"connection", b"keep-alive"],
+                            [b"keep-alive", b"timeout=300, max=1000"],
+                            [b"x-accel-buffering", b"no"],  # Disable nginx buffering
+                        ]
+                    )
+                    message = {**message, "headers": headers}
+                await send(message)
+
+            await self.app(scope, receive, send_wrapper)
+        else:
+            await self.app(scope, receive, send)


### PR DESCRIPTION
## Overview
This adds a middleware to try and explicitly keep the MCP connection alive for the duration of the initial setup with claude. 

## Discussion

I noticed that the logs from trying to point claude at localhost had a much longer process_time (`api-1      | event="Request processed" ... method=GET path=/mcp/sse process_time_ms=89493.09`) for exactly one request in the whole handshake process of trying to list tools etc. The same step when pointed at our lightsail deployment (`[7/Jul/2025:18:18:04] event="Request processed" ... method=GET path=/mcp/sse process_time_ms=2.88`) looks like it's returning much faster, which seemed fishy. 

Claude thinks this might be due to the amazon load balancer aggressively closing streaming connections that don't immediately send data (like the sanity check endpoint did), which would break the session state for the MCP server 

This middleware feels a little hacky but is less invasive than any other ideas I had 

## Testing

🤠 