### PR TITLE
Unique tags route

### DIFF
--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -169,6 +169,13 @@ async def search(
     )
 
 
+@router.get("/tags", response_model=list[str])
+async def get_unique_tags(db: AsyncSession = Depends(get_db_session)) -> list[str]:
+    stmt = select(func.unnest(Garden.tags).label("tag")).distinct()
+    result = await db.scalars(stmt)
+    return result.all()
+
+
 @router.get(
     "/{doi:path}",
     status_code=status.HTTP_200_OK,


### PR DESCRIPTION
Related to Garden-AI/garden#619

## Overview

This PR adds a new route at "gardens/tags" that aids the garden mcp search tool in supplying all the valid values for a `Garden.tags`. This is necessary to make sure mcp clients don't hallucinate invalid tag values when searching for gardens.

## Testing

Tested manually with Claude
