### PR TITLE
Add OR option to search filters

### DIFF
--- a/garden-backend-service/src/api/schemas/garden.py
+++ b/garden-backend-service/src/api/schemas/garden.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import AliasPath, Field, computed_field
@@ -111,6 +112,7 @@ class GardenPatchRequest(BaseSchema):
 class GardenSearchFilter(BaseSchema):
     field_name: str
     values: list[str]
+    operation: Literal["AND"] | Literal["OR"] = "AND"
 
 
 class GardenSearchFacets(BaseSchema):

--- a/garden-backend-service/src/api/schemas/garden.py
+++ b/garden-backend-service/src/api/schemas/garden.py
@@ -112,7 +112,7 @@ class GardenPatchRequest(BaseSchema):
 class GardenSearchFilter(BaseSchema):
     field_name: str
     values: list[str]
-    operation: Literal["AND", "OR"] = Field(default="AND")
+    operation: Literal["AND", "OR"] | None = Field(default="AND")
 
 
 class GardenSearchFacets(BaseSchema):

--- a/garden-backend-service/src/api/schemas/garden.py
+++ b/garden-backend-service/src/api/schemas/garden.py
@@ -112,7 +112,7 @@ class GardenPatchRequest(BaseSchema):
 class GardenSearchFilter(BaseSchema):
     field_name: str
     values: list[str]
-    operation: Literal["AND"] | Literal["OR"] = "AND"
+    operation: Literal["AND", "OR"] = Field(default="AND")
 
 
 class GardenSearchFacets(BaseSchema):

--- a/garden-backend-service/src/api/search/utils.py
+++ b/garden-backend-service/src/api/search/utils.py
@@ -1,4 +1,4 @@
-from sqlalchemy import asc, column, desc, func, select
+from sqlalchemy import asc, column, desc, func, or_, select
 from sqlalchemy.dialects.postgresql import ARRAY, TEXT
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Select
@@ -19,9 +19,7 @@ def apply_filters(
     Construct a new SQLAlchemy `Select` statement with applied filters.
 
     This function takes an existing SQLAlchemy `Select` statement and applies additional
-    `WHERE` clauses based on the provided `filters`. Each filter in the `filters` list is
-    ANDed together, meaning that all conditions must be satisfied for a row to be included
-    in the result.
+    `WHERE` clauses based on the provided `filters`.
 
     Args:
         model (Base): The SQLAlchemy model to which the filters should be applied.
@@ -51,24 +49,46 @@ def apply_filters(
         This will generate a query with `WHERE` clauses matching the title and tags.
     """
     for filter in filters:
+        or_conditions = []
         if not hasattr(model, filter.field_name):
             raise ValueError(f"Invalid filter field_name: {filter.field_name}")
         for value in filter.values:
             if filter.field_name == "owner":
-                stmt = stmt.join(getattr(model, filter.field_name)).where(
-                    User.name == value
-                )
-                continue
-            if type(getattr(model, filter.field_name)) is ARRAY:
-                stmt = stmt.where(
-                    func.array_to_string(getattr(model, filter.field_name), " ").match(
-                        value
+                if filter.operation == "OR":
+                    or_conditions.append(User.name == value)
+                else:
+                    stmt = stmt.join(getattr(model, filter.field_name)).where(
+                        User.name == value
                     )
-                )
+            elif type(getattr(model, filter.field_name)) is ARRAY:
+                if filter.operation == "OR":
+                    or_conditions.append(
+                        func.array_to_string(
+                            getattr(model, filter.field_name), " "
+                        ).match(value)
+                    )
+                else:
+                    stmt = stmt.where(
+                        func.array_to_string(
+                            getattr(model, filter.field_name), " "
+                        ).match(value)
+                    )
+            elif filter.field_name == "doi":
+                if filter.operation == "OR":
+                    or_conditions.append(getattr(model, filter.field_name) == value)
+                else:
+                    stmt = stmt.where(getattr(model, filter.field_name) == value)
             else:
-                stmt = stmt.where(
-                    func.cast(getattr(model, filter.field_name), TEXT).match(value)
-                )
+                if filter.operation == "OR":
+                    or_conditions.append(
+                        func.cast(getattr(model, filter.field_name), TEXT).match(value)
+                    )
+                else:
+                    stmt = stmt.where(
+                        func.cast(getattr(model, filter.field_name), TEXT).match(value)
+                    )
+        if or_conditions:
+            stmt = stmt.where(or_(*or_conditions))
     return stmt
 
 

--- a/garden-backend-service/tests/api/routes/test_gardens.py
+++ b/garden-backend-service/tests/api/routes/test_gardens.py
@@ -700,6 +700,48 @@ async def test_search_gardens_applies_filters_correctly(
 
 @pytest.mark.asyncio
 @pytest.mark.integration
+async def test_search_gardens_filters_by_doi(
+    client,
+    mock_db_session,
+    override_authenticated_dependency,
+    mock_garden_create_request_no_entrypoints_json,
+    mock_auth_state,
+):
+    g1 = mock_garden_create_request_no_entrypoints_json
+
+    g2 = deepcopy(mock_garden_create_request_no_entrypoints_json)
+    g2["authors"] = ["Phillip J. Fry"]
+
+    g3 = deepcopy(mock_garden_create_request_no_entrypoints_json)
+    g3["tags"] = ["testing"]
+    g3["description"] = "a garden for testing"
+
+    _ = await post_garden(client, g1)
+    created_g2 = await post_garden(client, g2)
+    created_g3 = await post_garden(client, g3)
+
+    body = {
+        "q": "",
+        "filters": [
+            {
+                "field_name": "doi",
+                "values": [created_g2["doi"], created_g3["doi"]],
+                "operation": "OR",
+            },
+        ],
+    }
+    response = await client.post("gardens/search", json=body)
+    assert response.status_code == 200
+
+    search_result = response.json()
+    assert len(search_result["garden_meta"]) == 2
+    dois = [g.get("doi") for g in search_result["garden_meta"]]
+    assert created_g2["doi"] in dois
+    assert created_g3["doi"] in dois
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
 async def test_search_gardens_returns_empty_list_when_no_matches(
     client,
     mock_db_session,


### PR DESCRIPTION
This PR is a companion to this FE PR: https://github.com/Garden-AI/garden-frontend/pull/424

## Overview

This adds the option to either 'AND' or 'OR' search filters in the `/gardens/search` route. This facilitates more options for filtering gardens from the frontend which reduces the number of network requests we need to send to populate the user's saved garden list.

## Testing
Added a new unit test that exercises the 'OR' option on DOI filters.