### PR TITLE
Fix: issue building deployment info for function responses

### DIFF
--- a/garden-backend-service/src/api/schemas/hpc.py
+++ b/garden-backend-service/src/api/schemas/hpc.py
@@ -13,9 +13,10 @@ class HpcFunctionCreateRequest(CommonFunctionMetadata):
 
 
 class HpcFunctionDeploymentInfo(BaseSchema):
-    deployment_ids: list[int]
+    deployment_id: int
     endpoint_name: str
     endpoint_gcmu_id: str
+    conda_env_path: str
 
 
 class HpcFunctionMetadataResponse(CommonFunctionMetadata):

--- a/garden-backend-service/src/models/functions/hpc/hpc_functions.py
+++ b/garden-backend-service/src/models/functions/hpc/hpc_functions.py
@@ -53,20 +53,27 @@ class HpcFunction(Base, DoiMixin, AssociatedMaterialsMixin, FunctionMetadataMixi
 
     @property
     def available_endpoints(self) -> list[str]:
-        if not self.deployment:
-            return []
-        return [endpoint.gcmu_id for endpoint in self.deployment.endpoints]
+        """Return unique list of endpoint IDs across all deployments."""
+        endpoint_ids = set()
+        for deployment in self.deployments:
+            for endpoint in deployment.endpoints:
+                endpoint_ids.add(endpoint.gcmu_id)
+        return list(endpoint_ids)
 
     @property
     def available_deployments(self) -> list[dict]:
-        if not self.deployment:
-            return []
+        """Return deployment info for each (deployment, endpoint) pair."""
+        result = []
 
-        return [
-            {
-                "deployment_id": self.deployment.id,
-                "endpoint_name": endpoint.name,
-                "endpoint_gcmu_id": endpoint.gcmu_id,
-            }
-            for endpoint in self.deployment.endpoints
-        ]
+        for deployment in self.deployments:
+            for endpoint in deployment.endpoints:
+                result.append(
+                    {
+                        "deployment_id": deployment.id,
+                        "endpoint_name": endpoint.name,
+                        "endpoint_gcmu_id": endpoint.gcmu_id,
+                        "conda_env_path": deployment.conda_env_path,
+                    }
+                )
+
+        return result


### PR DESCRIPTION
A quick fix/update to how we are building the deployment info to send down to the SDK. I wasn't tying the deployment info the the endpoint quite right, and forgot to add the conda_env_path.
