### PR TITLE
Create schemas, routes for hpc invocation tracking

### DIFF
--- a/garden-backend-service/src/api/routes/hpc_invocations.py
+++ b/garden-backend-service/src/api/routes/hpc_invocations.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from src.api.dependencies.auth import authed_user
+from src.api.dependencies.database import get_db_session
+from src.api.schemas.hpc_invocations import (
+    HpcInvocationCreateRequest,
+    HpcInvocationResponse,
+)
+from src.models.functions.hpc.hpc_endpoints import HpcEndpoint
+from src.models.functions.hpc.hpc_functions import HpcFunction
+from src.models.functions.hpc.hpc_invocations import HpcInvocationLog
+from src.models.user import User
+
+log = get_logger(__name__)
+
+router = APIRouter(prefix="/hpc")
+
+
+@router.post(
+    "/invocations",
+    response_model=HpcInvocationResponse,
+)
+async def create_hpc_invocation(
+    create_request: HpcInvocationCreateRequest,
+    db: AsyncSession = Depends(get_db_session),
+    user: User = Depends(authed_user),
+):
+    """Create a new HPC function invocation log entry."""
+    log.info("Creating HPC invocation log...")
+
+    # Verify the function exists
+    hpc_function = await HpcFunction.get(db, id=create_request.function_id)
+    if hpc_function is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"HPC Function not found with id {create_request.function_id}",
+        )
+
+    # Verify the endpoint exists and get its database ID
+    result = await db.execute(
+        select(HpcEndpoint).where(
+            HpcEndpoint.gcmu_id == create_request.endpoint_gcmu_id
+        )
+    )
+    hpc_endpoint = result.scalar_one_or_none()
+    if hpc_endpoint is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"HPC Endpoint not found with gcmu_id {create_request.endpoint_gcmu_id}",
+        )
+
+    # Create the invocation log
+    invocation_log = HpcInvocationLog(
+        user_id=user.id,
+        function_id=create_request.function_id,
+        hpc_endpoint_id=hpc_endpoint.id,
+        globus_task_id=create_request.globus_task_id,
+        date_invoked=datetime.now(),
+        user_endpoint_config=create_request.user_endpoint_config,
+    )
+
+    db.add(invocation_log)
+    await db.commit()
+    await db.refresh(invocation_log)
+
+    log.info(
+        "Created HPC invocation log",
+        invocation_id=invocation_log.id,
+        function_id=create_request.function_id,
+    )
+
+    return invocation_log
+
+
+@router.get("/invocations", response_model=list[HpcInvocationResponse])
+async def get_hpc_invocations(
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Get all HPC invocations."""
+    stmt = select(HpcInvocationLog)
+    result = await db.scalars(stmt)
+    return list(result.all())

--- a/garden-backend-service/src/api/schemas/hpc_invocations.py
+++ b/garden-backend-service/src/api/schemas/hpc_invocations.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from pydantic import Field
+
+from src.api.schemas.base import BaseSchema
+
+
+class HpcInvocationCreateRequest(BaseSchema):
+    function_id: int
+    endpoint_gcmu_id: str
+    globus_task_id: str
+    user_endpoint_config: dict = Field(default_factory=dict)
+
+
+class HpcInvocationResponse(BaseSchema):
+    id: int
+    user_id: int
+    function_id: int
+    hpc_endpoint_id: int
+    globus_task_id: str
+    date_invoked: datetime
+    user_endpoint_config: dict

--- a/garden-backend-service/src/main.py
+++ b/garden-backend-service/src/main.py
@@ -23,6 +23,7 @@ from src.api.routes import (
     hpc,
     hpc_deployments,
     hpc_endpoints,
+    hpc_invocations,
     load_test,
     modal,
     notebook,
@@ -112,6 +113,7 @@ app.include_router(modal.modal_file_metadata.router)
 app.include_router(hpc.router)
 app.include_router(hpc_deployments.router)
 app.include_router(hpc_endpoints.router)
+app.include_router(hpc_invocations.router)
 
 app.mount("/mcp-http", mcp.streamable_http_app())
 app.mount("/mcp-sse", mcp.sse_app())

--- a/garden-backend-service/tests/api/routes/hpc/test_hpc_invocations.py
+++ b/garden-backend-service/tests/api/routes/hpc/test_hpc_invocations.py
@@ -1,0 +1,147 @@
+import pytest
+
+
+async def create_hpc_endpoint(client, create_hpc_endpoint_json):
+    response = await client.post("/hpc/endpoints", json=create_hpc_endpoint_json)
+    assert response.status_code == 200
+    return response.json()
+
+
+async def create_hpc_deployment(client, create_hpc_deployment_json):
+    response = await client.post("/hpc/deployments", json=create_hpc_deployment_json)
+    assert response.status_code == 200
+    return response.json()
+
+
+async def create_hpc_function(client, create_hpc_function_json, deployment_id):
+    create_hpc_function_json["deployment_ids"] = [deployment_id]
+    response = await client.post("/hpc/functions", json=create_hpc_function_json)
+    assert response.status_code == 200
+    return response.json()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_create_hpc_invocation(
+    client,
+    mock_db_session,
+    override_authenticated_dependency,
+    create_hpc_endpoint_json,
+    create_hpc_deployment_json,
+    create_hpc_function_json,
+):
+    # Set up test data
+    endpoint = await create_hpc_endpoint(client, create_hpc_endpoint_json)
+    deployment = await create_hpc_deployment(client, create_hpc_deployment_json)
+    function = await create_hpc_function(
+        client, create_hpc_function_json, deployment["id"]
+    )
+
+    # Create invocation log
+    invocation_request = {
+        "function_id": function["id"],
+        "hpc_endpoint_id": endpoint["id"],
+        "globus_task_id": "550e8400-e29b-41d4-a716-446655440001",
+        "user_endpoint_config": {"key": "value"},
+    }
+
+    create_response = await client.post("/hpc/invocations", json=invocation_request)
+    assert create_response.status_code == 200
+    created_data = create_response.json()
+    assert created_data["function_id"] == function["id"]
+    assert created_data["hpc_endpoint_id"] == endpoint["id"]
+    assert created_data["globus_task_id"] == invocation_request["globus_task_id"]
+    assert created_data["user_endpoint_config"] == {"key": "value"}
+    assert "id" in created_data
+    assert "date_invoked" in created_data
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_hpc_invocations(
+    client,
+    mock_db_session,
+    override_authenticated_dependency,
+    create_hpc_endpoint_json,
+    create_hpc_deployment_json,
+    create_hpc_function_json,
+):
+    # Set up test data
+    endpoint = await create_hpc_endpoint(client, create_hpc_endpoint_json)
+    deployment = await create_hpc_deployment(client, create_hpc_deployment_json)
+    function = await create_hpc_function(
+        client, create_hpc_function_json, deployment["id"]
+    )
+
+    # Create two invocation logs
+    invocation_request_1 = {
+        "function_id": function["id"],
+        "hpc_endpoint_id": endpoint["id"],
+        "globus_task_id": "550e8400-e29b-41d4-a716-446655440001",
+        "user_endpoint_config": {},
+    }
+    invocation_request_2 = {
+        "function_id": function["id"],
+        "hpc_endpoint_id": endpoint["id"],
+        "globus_task_id": "550e8400-e29b-41d4-a716-446655440002",
+        "user_endpoint_config": {},
+    }
+
+    await client.post("/hpc/invocations", json=invocation_request_1)
+    await client.post("/hpc/invocations", json=invocation_request_2)
+
+    # Get all invocations
+    get_response = await client.get("/hpc/invocations")
+    assert get_response.status_code == 200
+    invocations = get_response.json()
+    assert len(invocations) == 2
+    assert invocations[0]["function_id"] == function["id"]
+    assert invocations[1]["function_id"] == function["id"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_create_invocation_nonexistent_function(
+    client,
+    mock_db_session,
+    override_authenticated_dependency,
+    create_hpc_endpoint_json,
+):
+    endpoint = await create_hpc_endpoint(client, create_hpc_endpoint_json)
+
+    invocation_request = {
+        "function_id": 99999,
+        "hpc_endpoint_id": endpoint["id"],
+        "globus_task_id": "550e8400-e29b-41d4-a716-446655440001",
+        "user_endpoint_config": {},
+    }
+
+    create_response = await client.post("/hpc/invocations", json=invocation_request)
+    assert create_response.status_code == 404
+    assert "HPC Function not found" in create_response.json()["detail"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_create_invocation_nonexistent_endpoint(
+    client,
+    mock_db_session,
+    override_authenticated_dependency,
+    create_hpc_deployment_json,
+    create_hpc_function_json,
+):
+    deployment = await create_hpc_deployment(client, create_hpc_deployment_json)
+    function = await create_hpc_function(
+        client, create_hpc_function_json, deployment["id"]
+    )
+
+    invocation_request = {
+        "function_id": function["id"],
+        "hpc_endpoint_id": 99999,
+        "globus_task_id": "550e8400-e29b-41d4-a716-446655440001",
+        "user_endpoint_config": {},
+    }
+
+    create_response = await client.post("/hpc/invocations", json=invocation_request)
+    assert create_response.status_code == 404
+    assert "HPC Endpoint not found" in create_response.json()["detail"]

--- a/garden-backend-service/tests/api/routes/hpc/test_hpc_invocations.py
+++ b/garden-backend-service/tests/api/routes/hpc/test_hpc_invocations.py
@@ -40,7 +40,7 @@ async def test_create_hpc_invocation(
     # Create invocation log
     invocation_request = {
         "function_id": function["id"],
-        "hpc_endpoint_id": endpoint["id"],
+        "endpoint_gcmu_id": endpoint["gcmu_id"],
         "globus_task_id": "550e8400-e29b-41d4-a716-446655440001",
         "user_endpoint_config": {"key": "value"},
     }
@@ -76,13 +76,13 @@ async def test_get_hpc_invocations(
     # Create two invocation logs
     invocation_request_1 = {
         "function_id": function["id"],
-        "hpc_endpoint_id": endpoint["id"],
+        "endpoint_gcmu_id": endpoint["gcmu_id"],
         "globus_task_id": "550e8400-e29b-41d4-a716-446655440001",
         "user_endpoint_config": {},
     }
     invocation_request_2 = {
         "function_id": function["id"],
-        "hpc_endpoint_id": endpoint["id"],
+        "endpoint_gcmu_id": endpoint["gcmu_id"],
         "globus_task_id": "550e8400-e29b-41d4-a716-446655440002",
         "user_endpoint_config": {},
     }
@@ -111,7 +111,7 @@ async def test_create_invocation_nonexistent_function(
 
     invocation_request = {
         "function_id": 99999,
-        "hpc_endpoint_id": endpoint["id"],
+        "endpoint_gcmu_id": endpoint["gcmu_id"],
         "globus_task_id": "550e8400-e29b-41d4-a716-446655440001",
         "user_endpoint_config": {},
     }
@@ -137,7 +137,7 @@ async def test_create_invocation_nonexistent_endpoint(
 
     invocation_request = {
         "function_id": function["id"],
-        "hpc_endpoint_id": 99999,
+        "endpoint_gcmu_id": "99999999-9999-9999-9999-999999999999",
         "globus_task_id": "550e8400-e29b-41d4-a716-446655440001",
         "user_endpoint_config": {},
     }


### PR DESCRIPTION
Resolves: #363 

## Overview

This PR creates a new `POST /hpc/invocations` route that adds records to the `hpc_invocation_logs` table, as well as a simple `GET` route to fetch invocation logs


## Testing

Some new tests to validate the route behaves properly.
