### PR TITLE
add function id to distict call

### DIFF
--- a/garden-backend-service/src/api/routes/hpc.py
+++ b/garden-backend-service/src/api/routes/hpc.py
@@ -61,7 +61,7 @@ async def get_hpc_functions(
             (HpcFunction.user_id == user.id)
             | (gardens_hpc_functions.c.garden_id.is_not(None))
         )
-        .distinct()
+        .distinct(HpcFunction.id)
     )
     result = await db.scalars(stmt)
     return list(result.all())


### PR DESCRIPTION
## Overview

Quick fix for an error in the `GET /hpc/functions` route. Error message:

```
{
  "detail": "Internal Server Error: (sqlalchemy.dialects.postgresql.asyncpg.ProgrammingError) <class 'asyncpg.exceptions.UndefinedFunctionError'>: could not identify an equality operator for type json[]\n[SQL: SELECT DISTINCT hpc_functions.id, hpc_functions.name, hpc_functions.user_id, hpc_functions.doi, hpc_functions.doi_is_draft, hpc_functions.is_archived, hpc_functions.models, hpc_functions.repositories, hpc_functions.papers, hpc_functions.datasets, hpc_functions.notebooks, hpc_functions.title, hpc_functions.authors, hpc_functions.description, hpc_functions.year, hpc_functions.tags, hpc_functions.function_name, hpc_functions.function_text, hpc_functions.example_usage, hpc_functions.test_functions, hpc_functions.requirements, hpc_functions.conda_requirements \nFROM hpc_functions LEFT OUTER JOIN gardens_hpc_functions ON hpc_functions.id = gardens_hpc_functions.hpc_function_id \nWHERE hpc_functions.user_id = $1::INTEGER OR gardens_hpc_functions.garden_id IS NOT NULL]\n[parameters: (2,)]\n(Background on this error at: https://sqlalche.me/e/20/f405)"
}
```

The fix is to provide something for the `distinct` call to use as an identifier.