### PR TITLE
Inlcude HPC functions in full-text search

### DIFF
--- a/garden-backend-service/src/api/search/sql.sql
+++ b/garden-backend-service/src/api/search/sql.sql
@@ -20,16 +20,26 @@ BEGIN
          INNER JOIN modal_function_documents mf
          ON gm.modal_function_id = mf.id
          GROUP BY gm.garden_id
+    ), hpc_function_ranks AS (
+         SELECT gm.garden_id,
+                COALESCE(SUM(ts_rank(hpcf.hpcf_document, query)), 0) AS rank
+         FROM gardens_hpc_functions gm
+         INNER JOIN hpc_function_documents hpcf
+         ON gm.hpc_function_id = hpcf.id
+         GROUP BY gm.garden_id
     ), garden_ranks AS (
        SELECT gd.garden_id,
               COALESCE(ts_rank(gd.garden_document, query), 0)
               + COALESCE(ep_ranks.rank, 0)
-              + COALESCE(mf_ranks.rank, 0) AS rank
+              + COALESCE(mf_ranks.rank, 0)
+              + COALESCE(hpcf_ranks.rank, 0) AS rank
        FROM garden_documents gd
        LEFT JOIN ep_ranks
        ON ep_ranks.garden_id = gd.garden_id
        LEFT JOIN modal_function_ranks mf_ranks
        ON mf_ranks.garden_id = gd.garden_id
+        LEFT JOIN hpc_function_ranks hpcf_ranks
+        ON hpcf_ranks.garden_id = gd.garden_id
     )
     SELECT gr.garden_id, gr.rank
     FROM garden_ranks gr
@@ -68,10 +78,19 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS modal_function_documents AS
     setweight(to_tsvector(mf.description), 'D') AS mf_document
     FROM modal_functions mf;
 
+CREATE MATERIALIZED VIEW IF NOT EXISTS hpc_function_documents AS
+    SELECT hpcf.id,
+    setweight(to_tsvector(array_to_string(hpcf.authors, ' ')), 'A') ||
+    setweight(to_tsvector(array_to_string(hpcf.tags, ' ')), 'A') ||
+    setweight(to_tsvector(hpcf.title), 'D') ||
+    setweight(to_tsvector(hpcf.description), 'D') AS hpcf_document
+    FROM hpc_functions hpcf;
+
 
 CREATE INDEX IF NOT EXISTS garden_documents_index ON garden_documents USING GIN(garden_document);
 CREATE INDEX IF NOT EXISTS entrypoint_documents_index ON entrypoint_documents USING GIN(ep_document);
 CREATE INDEX IF NOT EXISTS modal_function_documents_index ON modal_function_documents USING GIN(mf_document);
+CREATE INDEX IF NOT EXISTS hpc_function_documents_index ON hpc_function_documents USING GIN(hpcf_document);
 
 
 CREATE OR REPLACE FUNCTION refresh_garden_documents()
@@ -109,6 +128,17 @@ $$
 LANGUAGE plpgsql
 ;
 
+CREATE OR REPLACE FUNCTION refresh_hpc_function_documents()
+RETURNS TRIGGER
+AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW hpc_function_documents;
+    RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql
+;
+
 CREATE OR REPLACE TRIGGER garden_documents_trigger
 AFTER INSERT OR UPDATE OF authors,
                 contributors,
@@ -135,3 +165,11 @@ AFTER INSERT OR UPDATE OF authors,
                 title
 ON modal_functions
 EXECUTE FUNCTION refresh_modal_function_documents();
+
+CREATE OR REPLACE TRIGGER hpc_function_documents_trigger
+AFTER INSERT OR UPDATE OF authors,
+                tags,
+                description,
+                title
+ON hpc_functions
+EXECUTE FUNCTION refresh_hpc_function_documents();

--- a/garden-backend-service/src/api/search/sql.sql
+++ b/garden-backend-service/src/api/search/sql.sql
@@ -53,6 +53,7 @@ language plpgsql
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS garden_documents AS
     SELECT g.id AS garden_id,
+    setweight(to_tsvector('simple', g.doi), 'A') || -- 'simple' keeps DOI intact
     setweight(to_tsvector(array_to_string(g.authors, ' ')), 'A') ||
     setweight(to_tsvector(array_to_string(g.contributors, ' ')), 'A') ||
     setweight(to_tsvector(array_to_string(g.tags, ' ')), 'B') ||

--- a/garden-backend-service/tests/conftest.py
+++ b/garden-backend-service/tests/conftest.py
@@ -148,6 +148,7 @@ def mock_db_session(
         db.execute(text("DROP MATERIALIZED VIEW IF EXISTS garden_documents;"))
         db.execute(text("DROP MATERIALIZED VIEW IF EXISTS entrypoint_documents;"))
         db.execute(text("DROP MATERIALIZED VIEW IF EXISTS modal_function_documents;"))
+        db.execute(text("DROP MATERIALIZED VIEW IF EXISTS hpc_function_documents;"))
         db.commit()
     Base.metadata.drop_all(_sync_engine)
 
@@ -167,6 +168,7 @@ async def async_db_session(mock_settings, _sync_engine):
         db.execute(text("DROP MATERIALIZED VIEW garden_documents;"))
         db.execute(text("DROP MATERIALIZED VIEW entrypoint_documents;"))
         db.execute(text("DROP MATERIALIZED VIEW modal_function_documents;"))
+        db.execute(text("DROP MATERIALIZED VIEW hpc_function_documents;"))
         db.commit()
     Base.metadata.drop_all(_sync_engine)
     await async_engine.dispose()


### PR DESCRIPTION
Resolves: #368 
Bonus, Resolves: #342 

## Overview

This PR adds a materialized view for text-search vectorized documents of HPC function metadata called `hpc_function_documents`. The `search_gardens` function is updated to include the HPC function documents in the search and relevance rankings. I also added helper function to refresh the materialized view, and a trigger to trigger the refresh when HPC function records are updated.

As a bonus, since it was a single line addition, I added garden DOIs in the full-text search to accommodate the use case where someone has the DOI for a garden and pastes it into the search input. Before we wouldn't return any matching gardens, now the garden with a matching DOI is the 'most relevant' result.

## Testing

Manual testing using the frontend. Gardens with HPC functions are correctly returned by the search route and all facet counts are accurate.