### PR TITLE
Add hpc function and endpoint filtering and facets counts to search

### DIFF
--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -7,6 +7,7 @@ from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
 from src.api.dependencies.auth import authed_user
@@ -34,6 +35,7 @@ from src.datacite.doi_utils import (
 )
 from src.models import Entrypoint, Garden, ModalFunction, User
 from src.models.functions.hpc.hpc_functions import HpcFunction
+from src.models.functions.modal.modal_app import ModalApp
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/gardens")
@@ -81,8 +83,24 @@ async def search_gardens(
     """
     # Handle function-specific search
     if function_ids is not None:
-        stmt = select(Garden).where(
-            Garden.modal_functions.any(ModalFunction.id.in_(function_ids))
+        stmt = (
+            select(Garden)
+            .where(Garden.modal_functions.any(ModalFunction.id.in_(function_ids)))
+            .options(
+                selectinload(Garden.user),
+                selectinload(Garden.entrypoints).selectinload(Entrypoint.user),
+                selectinload(Garden.modal_functions)
+                .selectinload(ModalFunction.modal_app)
+                .selectinload(ModalApp.user),
+                selectinload(Garden.modal_functions).selectinload(
+                    ModalFunction.invocation_logs
+                ),
+                selectinload(Garden.hpc_functions).selectinload(HpcFunction.user),
+                selectinload(Garden.hpc_functions).selectinload(HpcFunction.endpoints),
+                selectinload(Garden.hpc_functions).selectinload(
+                    HpcFunction.invocation_logs
+                ),
+            )
         )
         result = await db.scalars(stmt.limit(limit))
         gardens = list(result.all())
@@ -112,6 +130,21 @@ async def search_gardens(
 
     if year is not None:
         stmt = stmt.where(Garden.year == year)
+
+    # Eagerly load all nested relationships to avoid N+1 queries
+    stmt = stmt.options(
+        selectinload(Garden.user),
+        selectinload(Garden.entrypoints).selectinload(Entrypoint.user),
+        selectinload(Garden.modal_functions)
+        .selectinload(ModalFunction.modal_app)
+        .selectinload(ModalApp.user),
+        selectinload(Garden.modal_functions).selectinload(
+            ModalFunction.invocation_logs
+        ),
+        selectinload(Garden.hpc_functions).selectinload(HpcFunction.user),
+        selectinload(Garden.hpc_functions).selectinload(HpcFunction.endpoints),
+        selectinload(Garden.hpc_functions).selectinload(HpcFunction.invocation_logs),
+    )
 
     result = await db.scalars(stmt.limit(limit))
     gardens = list(result.all())
@@ -159,6 +192,21 @@ async def search(
             stmt = sort_results(Garden, stmt, search_request.sort)
         except ValueError as e:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    # Eagerly load all nested relationships to avoid N+1 queries
+    stmt = stmt.options(
+        selectinload(Garden.user),
+        selectinload(Garden.entrypoints).selectinload(Entrypoint.user),
+        selectinload(Garden.modal_functions)
+        .selectinload(ModalFunction.modal_app)
+        .selectinload(ModalApp.user),
+        selectinload(Garden.modal_functions).selectinload(
+            ModalFunction.invocation_logs
+        ),
+        selectinload(Garden.hpc_functions).selectinload(HpcFunction.user),
+        selectinload(Garden.hpc_functions).selectinload(HpcFunction.endpoints),
+        selectinload(Garden.hpc_functions).selectinload(HpcFunction.invocation_logs),
+    )
 
     # Run the search query
     result = await db.scalars(stmt)

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -122,7 +122,7 @@ async def search_gardens(
 @router.post(
     "/search",
     status_code=status.HTTP_200_OK,
-    # response_model=GardenSearchResponse,  # TEMPORARILY DISABLED FOR PERFORMANCE TEST
+    response_model=GardenSearchResponse,
 )
 async def search(
     search_request: GardenSearchRequest,

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -7,7 +7,6 @@ from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
 from src.api.dependencies.auth import authed_user
@@ -35,7 +34,6 @@ from src.datacite.doi_utils import (
 )
 from src.models import Entrypoint, Garden, ModalFunction, User
 from src.models.functions.hpc.hpc_functions import HpcFunction
-from src.models.functions.modal.modal_app import ModalApp
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/gardens")
@@ -83,24 +81,8 @@ async def search_gardens(
     """
     # Handle function-specific search
     if function_ids is not None:
-        stmt = (
-            select(Garden)
-            .where(Garden.modal_functions.any(ModalFunction.id.in_(function_ids)))
-            .options(
-                selectinload(Garden.user),
-                selectinload(Garden.entrypoints).selectinload(Entrypoint.user),
-                selectinload(Garden.modal_functions)
-                .selectinload(ModalFunction.modal_app)
-                .selectinload(ModalApp.user),
-                selectinload(Garden.modal_functions).selectinload(
-                    ModalFunction.invocation_logs
-                ),
-                selectinload(Garden.hpc_functions).selectinload(HpcFunction.user),
-                selectinload(Garden.hpc_functions).selectinload(HpcFunction.endpoints),
-                selectinload(Garden.hpc_functions).selectinload(
-                    HpcFunction.invocation_logs
-                ),
-            )
+        stmt = select(Garden).where(
+            Garden.modal_functions.any(ModalFunction.id.in_(function_ids))
         )
         result = await db.scalars(stmt.limit(limit))
         gardens = list(result.all())
@@ -131,21 +113,6 @@ async def search_gardens(
     if year is not None:
         stmt = stmt.where(Garden.year == year)
 
-    # Eagerly load all nested relationships to avoid N+1 queries
-    stmt = stmt.options(
-        selectinload(Garden.user),
-        selectinload(Garden.entrypoints).selectinload(Entrypoint.user),
-        selectinload(Garden.modal_functions)
-        .selectinload(ModalFunction.modal_app)
-        .selectinload(ModalApp.user),
-        selectinload(Garden.modal_functions).selectinload(
-            ModalFunction.invocation_logs
-        ),
-        selectinload(Garden.hpc_functions).selectinload(HpcFunction.user),
-        selectinload(Garden.hpc_functions).selectinload(HpcFunction.endpoints),
-        selectinload(Garden.hpc_functions).selectinload(HpcFunction.invocation_logs),
-    )
-
     result = await db.scalars(stmt.limit(limit))
     gardens = list(result.all())
 
@@ -155,7 +122,7 @@ async def search_gardens(
 @router.post(
     "/search",
     status_code=status.HTTP_200_OK,
-    response_model=GardenSearchResponse,
+    # response_model=GardenSearchResponse,  # TEMPORARILY DISABLED FOR PERFORMANCE TEST
 )
 async def search(
     search_request: GardenSearchRequest,
@@ -192,21 +159,6 @@ async def search(
             stmt = sort_results(Garden, stmt, search_request.sort)
         except ValueError as e:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-
-    # Eagerly load all nested relationships to avoid N+1 queries
-    stmt = stmt.options(
-        selectinload(Garden.user),
-        selectinload(Garden.entrypoints).selectinload(Entrypoint.user),
-        selectinload(Garden.modal_functions)
-        .selectinload(ModalFunction.modal_app)
-        .selectinload(ModalApp.user),
-        selectinload(Garden.modal_functions).selectinload(
-            ModalFunction.invocation_logs
-        ),
-        selectinload(Garden.hpc_functions).selectinload(HpcFunction.user),
-        selectinload(Garden.hpc_functions).selectinload(HpcFunction.endpoints),
-        selectinload(Garden.hpc_functions).selectinload(HpcFunction.invocation_logs),
-    )
 
     # Run the search query
     result = await db.scalars(stmt)

--- a/garden-backend-service/src/api/schemas/garden.py
+++ b/garden-backend-service/src/api/schemas/garden.py
@@ -129,6 +129,8 @@ class GardenSearchFacets(BaseSchema):
     model_authors: dict[str, int] = Field(default_factory=dict)
     gardeners: dict[str, int] = Field(default_factory=dict)
     year: dict[str, int] = Field(default_factory=dict)
+    function_type: dict[str, int] = Field(default_factory=dict)
+    hpc_endpoint: dict[str, int] = Field(default_factory=dict)
 
 
 class GardenSearchSort(BaseSchema):

--- a/garden-backend-service/src/api/search/utils.py
+++ b/garden-backend-service/src/api/search/utils.py
@@ -9,7 +9,82 @@ from src.api.schemas.garden import (
     GardenSearchSort,
 )
 from src.models import User
+from src.models._associations import gardens_hpc_functions, hpc_functions_hpc_endpoints
 from src.models.base import Base
+from src.models.functions.hpc.hpc_endpoints import HpcEndpoint
+
+
+def apply_function_type_filter(
+    model: type[Base],
+    stmt: Select,
+    values: list[str],
+) -> Select:
+    """
+    Filter gardens by function type (modal, hpc, or both).
+
+    Args:
+        model: The Garden model
+        stmt: The SQLAlchemy Select statement
+        values: List of function types - ["modal"], ["hpc"], or ["modal", "hpc"]
+
+    Returns:
+        Modified Select statement with function type filter applied
+    """
+    if not values:
+        return stmt
+
+    function_type_conditions = []
+
+    for value in values:
+        if value == "modal":
+            # Garden has at least one modal function
+            function_type_conditions.append(getattr(model, "modal_functions").any())
+        elif value == "hpc":
+            # Garden has at least one HPC function
+            function_type_conditions.append(getattr(model, "hpc_functions").any())
+
+    # Apply OR logic: garden must have at least one of the requested function types
+    if function_type_conditions:
+        stmt = stmt.where(or_(*function_type_conditions))
+
+    return stmt
+
+
+def apply_hpc_endpoints_filter(
+    model: type[Base], stmt: Select, endpoint_names: list[str]
+) -> Select:
+    """
+    Filter gardens that have HPC functions available on specific endpoints.
+
+    Args:
+        model: The Garden model
+        stmt: The SQLAlchemy Select statement
+        endpoint_names: List of HPC endpoint names (e.g., ["Polaris", "Perlmutter"])
+
+    Returns:
+        Modified Select statement with HPC endpoint filter applied
+    """
+    if not endpoint_names:
+        return stmt
+
+    # Filter to gardens where ANY HPC function has ANY of the specified endpoints
+    subquery = (
+        select(gardens_hpc_functions.c.garden_id)
+        .join(
+            hpc_functions_hpc_endpoints,
+            gardens_hpc_functions.c.hpc_function_id
+            == hpc_functions_hpc_endpoints.c.hpc_function_id,
+        )
+        .join(
+            HpcEndpoint,
+            hpc_functions_hpc_endpoints.c.hpc_endpoint_id == HpcEndpoint.id,
+        )
+        .where(HpcEndpoint.name.in_(endpoint_names))
+    )
+
+    stmt = stmt.where(getattr(model, "id").in_(subquery))
+
+    return stmt
 
 
 def apply_filters(
@@ -49,9 +124,19 @@ def apply_filters(
         This will generate a query with `WHERE` clauses matching the title and tags.
     """
     for filter in filters:
-        or_conditions = []
+        if filter.field_name == "function_type":
+            stmt = apply_function_type_filter(model, stmt, filter.values)
+            continue
+
+        if filter.field_name == "hpc_endpoints":
+            stmt = apply_hpc_endpoints_filter(model, stmt, filter.values)
+            continue
+
+        # Validate that the field exists on the model for standard filters
         if not hasattr(model, filter.field_name):
             raise ValueError(f"Invalid filter field_name: {filter.field_name}")
+
+        or_conditions = []
         for value in filter.values:
             if filter.field_name == "owner":
                 if filter.operation == "OR":

--- a/garden-backend-service/src/api/search/utils.py
+++ b/garden-backend-service/src/api/search/utils.py
@@ -1,4 +1,4 @@
-from sqlalchemy import asc, column, desc, func, or_, select
+from sqlalchemy import asc, column, desc, func, literal_column, or_, select
 from sqlalchemy.dialects.postgresql import ARRAY, TEXT
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Select
@@ -9,7 +9,11 @@ from src.api.schemas.garden import (
     GardenSearchSort,
 )
 from src.models import User
-from src.models._associations import gardens_hpc_functions, hpc_functions_hpc_endpoints
+from src.models._associations import (
+    gardens_hpc_functions,
+    gardens_modal_functions,
+    hpc_functions_hpc_endpoints,
+)
 from src.models.base import Base
 from src.models.functions.hpc.hpc_endpoints import HpcEndpoint
 
@@ -229,18 +233,78 @@ async def calculate_facets(db: AsyncSession, query: Select) -> GardenSearchFacet
         filtered_gardens.c.year.label("year"), func.count().label("count")
     ).group_by(column("year"))
 
+    # Function types facet: count gardens by whether they have modal/hpc functions
+    # Use UNION to get counts for both types
+    modal_count_query = (
+        select(
+            literal_column("'modal'").label("function_type"),
+            func.count().label("count"),
+        )
+        .select_from(filtered_gardens)
+        .where(
+            select(1)
+            .select_from(gardens_modal_functions)
+            .where(gardens_modal_functions.c.garden_id == filtered_gardens.c.id)
+            .exists()
+        )
+    )
+
+    hpc_count_query = (
+        select(
+            literal_column("'hpc'").label("function_type"), func.count().label("count")
+        )
+        .select_from(filtered_gardens)
+        .where(
+            select(1)
+            .select_from(gardens_hpc_functions)
+            .where(gardens_hpc_functions.c.garden_id == filtered_gardens.c.id)
+            .exists()
+        )
+    )
+
+    function_types_query = modal_count_query.union_all(hpc_count_query)
+
+    # HPC endpoints facet: count unique endpoint names across all HPC functions
+    hpc_endpoints_query = (
+        select(HpcEndpoint.name.label("endpoint"), func.count().label("count"))
+        .select_from(filtered_gardens)
+        .join(
+            gardens_hpc_functions,
+            filtered_gardens.c.id == gardens_hpc_functions.c.garden_id,
+        )
+        .join(
+            hpc_functions_hpc_endpoints,
+            gardens_hpc_functions.c.hpc_function_id
+            == hpc_functions_hpc_endpoints.c.hpc_function_id,
+        )
+        .join(
+            HpcEndpoint,
+            hpc_functions_hpc_endpoints.c.hpc_endpoint_id == HpcEndpoint.id,
+        )
+        .group_by(HpcEndpoint.name)
+    )
+
     tags_result = await db.execute(tags_query)
     authors_result = await db.execute(authors_query)
     gardeners_result = await db.execute(gardeners_query)
     year_result = await db.execute(year_query)
+    function_types_result = await db.execute(function_types_query)
+    hpc_endpoints_result = await db.execute(hpc_endpoints_query)
 
     tags = {row[0]: row[1] for row in tags_result.all()}
     authors = {row[0]: row[1] for row in authors_result.all()}
     gardeners = {row[0]: row[1] for row in gardeners_result.all()}
     year = {str(row[0]): row[1] for row in year_result.all()}
+    function_types = {row[0]: row[1] for row in function_types_result.all()}
+    hpc_endpoints = {row[0]: row[1] for row in hpc_endpoints_result.all()}
 
     return GardenSearchFacets(
-        tags=tags, model_authors=authors, gardeners=gardeners, year=year
+        tags=tags,
+        model_authors=authors,
+        gardeners=gardeners,
+        year=year,
+        function_type=function_types,
+        hpc_endpoint=hpc_endpoints,
     )
 
 


### PR DESCRIPTION
Resolves: #376 

## Overview

This PR moves the filtering and facet counts for hpc functions and endpoints to the backend following some issues we found doing it client-side in https://github.com/Garden-AI/garden-frontend/pull/469.

## Testing

Existing search tests still pass.
Manual testing via the frontend, filters and facets look correct.
