### PR TITLE
Optimize search data transfer and serialization

### DIFF
--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -20,6 +20,7 @@ from src.api.schemas.garden import (
     GardenCreateRequest,
     GardenMetadataResponse,
     GardenPatchRequest,
+    GardenSearchMetadataResponse,
     GardenSearchRequest,
     GardenSearchResponse,
     GardenState,
@@ -60,7 +61,7 @@ async def add_garden(
 
 
 @router.get(
-    "", response_model=list[GardenMetadataResponse], operation_id="search_gardens"
+    "", response_model=list[GardenSearchMetadataResponse], operation_id="search_gardens"
 )
 async def search_gardens(
     doi: Annotated[list[str] | None, Query()] = None,

--- a/garden-backend-service/src/api/routes/gardens.py
+++ b/garden-backend-service/src/api/routes/gardens.py
@@ -7,6 +7,7 @@ from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
 from src.api.dependencies.auth import authed_user
@@ -35,9 +36,32 @@ from src.datacite.doi_utils import (
 )
 from src.models import Entrypoint, Garden, ModalFunction, User
 from src.models.functions.hpc.hpc_functions import HpcFunction
+from src.models.functions.modal.modal_app import ModalApp
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/gardens")
+
+
+def _defer_search_text_fields():
+    """
+    Returns SQLAlchemy load options that defer heavy text fields
+    for search results to reduce data transfer and serialization time.
+
+    This defers:
+    - ModalFunction.function_text (large Python function code)
+    - ModalApp.file_contents (large Python file with app definition)
+    - HpcFunction.function_text (large Python function code)
+    """
+    return [
+        # Defer heavy text fields in related modal functions
+        selectinload(Garden.modal_functions).defer(ModalFunction.function_text),
+        # Defer heavy file_contents from modal_app
+        selectinload(Garden.modal_functions)
+        .selectinload(ModalFunction.modal_app)
+        .defer(ModalApp.file_contents),
+        # Defer heavy text fields in related HPC functions
+        selectinload(Garden.hpc_functions).defer(HpcFunction.function_text),
+    ]
 
 
 class StateTransition(str, Enum):
@@ -82,8 +106,10 @@ async def search_gardens(
     """
     # Handle function-specific search
     if function_ids is not None:
-        stmt = select(Garden).where(
-            Garden.modal_functions.any(ModalFunction.id.in_(function_ids))
+        stmt = (
+            select(Garden)
+            .where(Garden.modal_functions.any(ModalFunction.id.in_(function_ids)))
+            .options(*_defer_search_text_fields())
         )
         result = await db.scalars(stmt.limit(limit))
         gardens = list(result.all())
@@ -91,7 +117,7 @@ async def search_gardens(
         return gardens
 
     # Handle general search
-    stmt = select(Garden)
+    stmt = select(Garden).options(*_defer_search_text_fields())
 
     if doi is not None:
         stmt = stmt.where(Garden.doi.in_(doi))
@@ -129,7 +155,7 @@ async def search(
     search_request: GardenSearchRequest,
     db: AsyncSession = Depends(get_db_session),
 ) -> GardenSearchResponse:
-    stmt = select(Garden)
+    stmt = select(Garden).options(*_defer_search_text_fields())
 
     # Apply filters to query
     try:

--- a/garden-backend-service/src/api/schemas/garden.py
+++ b/garden-backend-service/src/api/schemas/garden.py
@@ -8,8 +8,11 @@ from src.models.garden import GardenState
 
 from .base import BaseSchema, UniqueList
 from .entrypoint import EntrypointMetadataResponse
-from .hpc import HpcFunctionMetadataResponse
-from .modal.modal_function import ModalFunctionMetadataResponse
+from .hpc import HpcFunctionMetadataResponse, HpcFunctionSearchResult
+from .modal.modal_function import (
+    ModalFunctionMetadataResponse,
+    ModalFunctionSearchResult,
+)
 
 
 class GardenMetadata(BaseSchema):
@@ -48,6 +51,31 @@ class GardenMetadataResponse(GardenMetadata):
     entrypoints: list[EntrypointMetadataResponse] = Field(default_factory=list)
     modal_functions: list[ModalFunctionMetadataResponse] = Field(default_factory=list)
     hpc_functions: list[HpcFunctionMetadataResponse] = Field(default_factory=list)
+    marked_for_deletion: datetime | None
+
+    @computed_field
+    @property
+    def entrypoint_ids(self) -> list[str]:
+        return [ep.doi for ep in self.entrypoints]
+
+    @computed_field
+    @property
+    def modal_function_ids(self) -> list[int]:
+        return [mf.id for mf in self.modal_functions]
+
+    @computed_field
+    @property
+    def hpc_function_ids(self) -> list[int]:
+        return [hpcf.id for hpcf in self.hpc_functions]
+
+
+class GardenSearchMetadataResponse(GardenMetadata):
+    owner: str = Field(validation_alias=AliasPath("owner", "name"))
+    owner_identity_id: UUID = Field(validation_alias=AliasPath("owner", "identity_id"))
+    id: int
+    entrypoints: list[EntrypointMetadataResponse] = Field(default_factory=list)
+    modal_functions: list[ModalFunctionSearchResult] = Field(default_factory=list)
+    hpc_functions: list[HpcFunctionSearchResult] = Field(default_factory=list)
     marked_for_deletion: datetime | None
 
     @computed_field
@@ -152,5 +180,5 @@ class GardenSearchResponse(BaseSchema):
     count: int
     total: int
     offset: int
-    garden_meta: list[GardenMetadataResponse]
+    garden_meta: list[GardenSearchMetadataResponse]
     facets: GardenSearchFacets

--- a/garden-backend-service/src/api/schemas/hpc.py
+++ b/garden-backend-service/src/api/schemas/hpc.py
@@ -3,6 +3,7 @@ from pydantic import Field
 from src.api.schemas.base import BaseSchema
 from src.api.schemas.shared_function_schemas import (
     CommonFunctionMetadata,
+    CommonFunctionMetadataSearchResult,
     CommonFunctionPatchRequest,
 )
 
@@ -17,11 +18,15 @@ class HpcEndpointInfo(BaseSchema):
     gcmu_id: str | None
 
 
-class HpcFunctionMetadataResponse(CommonFunctionMetadata):
+class HpcFunctionSearchResult(CommonFunctionMetadataSearchResult):
     id: int
     function_name: str
     available_endpoints: list[HpcEndpointInfo] = Field(default_factory=list)
     num_invocations: int = 0
+
+
+class HpcFunctionMetadataResponse(HpcFunctionSearchResult, CommonFunctionMetadata):
+    pass
 
 
 class HpcFunctionPatchRequest(CommonFunctionPatchRequest):

--- a/garden-backend-service/src/api/schemas/modal/modal_function.py
+++ b/garden-backend-service/src/api/schemas/modal/modal_function.py
@@ -2,13 +2,16 @@ from uuid import UUID
 
 from pydantic import AliasPath, Field
 
-from ..shared_function_schemas import CommonFunctionMetadata, CommonFunctionPatchRequest
+from ..shared_function_schemas import (
+    CommonFunctionMetadata,
+    CommonFunctionMetadataSearchResult,
+    CommonFunctionPatchRequest,
+)
 
 
-class ModalFunctionMetadata(CommonFunctionMetadata):
+class ModalFunctionMetadataBase(CommonFunctionMetadata):
     # Equivalent to "short_name" on entrypoints
     function_name: str
-    file_contents: str | None = None
     # Modal functions get a DOI when they are published
     # If they don't have a DOI, they are in draft state
     doi: str | None = None
@@ -17,7 +20,11 @@ class ModalFunctionMetadata(CommonFunctionMetadata):
     example_usage: str = ""
 
 
-class ModalFunctionMetadataResponse(ModalFunctionMetadata):
+class ModalFunctionMetadata(ModalFunctionMetadataBase):
+    file_contents: str | None = None
+
+
+class ModalFunctionSearchResult(CommonFunctionMetadataSearchResult):
     id: int = Field(..., description="The unique identifier for the modal function")
     modal_app_id: int
     owner: str = Field("", validation_alias=AliasPath("owner", "name"))
@@ -27,6 +34,10 @@ class ModalFunctionMetadataResponse(ModalFunctionMetadata):
         default_factory=lambda: 0,
         description="The number of times this function has been invoked",
     )
+
+
+class ModalFunctionMetadataResponse(ModalFunctionSearchResult, ModalFunctionMetadata):
+    pass
 
 
 class ModalFunctionPatchRequest(CommonFunctionPatchRequest):

--- a/garden-backend-service/src/api/schemas/shared_function_schemas.py
+++ b/garden-backend-service/src/api/schemas/shared_function_schemas.py
@@ -39,10 +39,8 @@ class _NotebookMetadata(BaseRelatedMetadataSchema):
     url: Url
 
 
-class CommonFunctionMetadata(BaseSchema):
+class CommonFunctionMetadataBase(BaseSchema):
     is_archived: bool = False
-
-    function_text: str
 
     title: str
     description: str | None
@@ -58,6 +56,14 @@ class CommonFunctionMetadata(BaseSchema):
     papers: list[_PaperMetadata] = Field(default_factory=list)
     datasets: list[_DatasetMetadata] = Field(default_factory=list)
     notebooks: list[_NotebookMetadata] = Field(default_factory=list)
+
+
+class CommonFunctionMetadata(CommonFunctionMetadataBase):
+    function_text: str
+
+
+class CommonFunctionMetadataSearchResult(CommonFunctionMetadataBase):
+    pass
 
 
 class CommonFunctionPatchRequest(BaseSchema):


### PR DESCRIPTION
## Overview

This PR adds some new pydantic schemas that leave out the `function_text`, `app_source`, and `file_contents` fields on function types and modal apps during search queries. In my local testing this has shown to reduce total data transfer by close to a full order of magnitude, and should (in theory) greatly reduce the serialization overhead when returning large sets of gardens.

I also added `defer` options to the SQL queries as per these docs: https://docs.sqlalchemy.org/en/20/orm/queryguide/columns.html#using-defer-to-omit-specific-columns so we can avoid loading the large text fields form the database as well.

## Discussion

This means the frontend will have to query again for the full function metadata when it needs to display the function text, but that should be a worthwhile tradeoff.

## Testing

Manually

_Before -- Sending the full function metadata_ -- ~30kB transferred for two gardens with 7 functions total
<img width="3418" height="390" alt="image" src="https://github.com/user-attachments/assets/a4dfb327-c2c1-407a-a87f-a0c0f21b8049" />

_After -- Omitting the large text-fields_ -- ~4.2kB transferred for the same search query
<img width="3418" height="390" alt="image (1)" src="https://github.com/user-attachments/assets/c2a4773e-d0fc-4c52-9cc4-601b2a6783f6" />
