### PR TITLE
better modal invocation polling

### DIFF
--- a/garden-backend-service/src/api/routes/benchmarks.py
+++ b/garden-backend-service/src/api/routes/benchmarks.py
@@ -128,6 +128,7 @@ async def run_benchmark(
 async def get_results_for_benchmark_task(
     benchmark_id: int,
     task_id: int,
+    background_tasks: BackgroundTasks,
     include_failed: bool = Query(default=False),
     modal_client: Client = Depends(get_modal_client),
     db: AsyncSession = Depends(get_db_session),
@@ -166,6 +167,7 @@ async def get_results_for_benchmark_task(
         modal_client,
         logger,
         include_failed,
+        background_tasks,
     )
     return benchmark_results
 
@@ -212,6 +214,7 @@ async def _get_results_for_runs(
     modal_client: Client,
     logger,
     include_failed: bool,
+    background_tasks: BackgroundTasks,
 ) -> list[BenchmarkResult]:
     """"""
     results = []
@@ -219,7 +222,7 @@ async def _get_results_for_runs(
         try:
             # Get the invocation result
             invocation_output = await get_modal_invocation_output(
-                benchmark_run.invocation_id, modal_client, db
+                benchmark_run.invocation_id, background_tasks, modal_client, db
             )
             if not invocation_output:
                 # Skip runs with missing invocation output

--- a/garden-backend-service/src/api/routes/modal/invocations.py
+++ b/garden-backend-service/src/api/routes/modal/invocations.py
@@ -50,12 +50,12 @@ def _has_monitoring_task_for_invocation(
     Returns:
         True if a monitoring task for this invocation_id already exists, False otherwise
     """
-    # BackgroundTasks.tasks is a list of tuples: (func, args, kwargs)
-    for task_func, task_args, task_kwargs in background_tasks.tasks:
+    # BackgroundTasks.tasks is a list of BackgroundTask objects
+    for task in background_tasks.tasks:
         # Check if this is a monitor_modal_invocation task
-        if task_func == monitor_modal_invocation:
+        if task.func == monitor_modal_invocation:
             # The second argument (index 1) is the db_result_id
-            if len(task_args) > 1 and task_args[1] == invocation_id:
+            if len(task.args) > 1 and task.args[1] == invocation_id:
                 return True
     return False
 

--- a/garden-backend-service/src/api/routes/modal/invocations.py
+++ b/garden-backend-service/src/api/routes/modal/invocations.py
@@ -38,6 +38,28 @@ logger = structlog.get_logger(__name__)
 router = APIRouter(prefix="/modal-invocations")
 
 
+def _has_monitoring_task_for_invocation(
+    background_tasks: BackgroundTasks, invocation_id: int
+) -> bool:
+    """Check if there's already a monitoring task for this invocation in the background tasks.
+
+    Args:
+        background_tasks: The FastAPI BackgroundTasks object from the current request
+        invocation_id: The ID of the invocation to check for
+
+    Returns:
+        True if a monitoring task for this invocation_id already exists, False otherwise
+    """
+    # BackgroundTasks.tasks is a list of tuples: (func, args, kwargs)
+    for task_func, task_args, task_kwargs in background_tasks.tasks:
+        # Check if this is a monitor_modal_invocation task
+        if task_func == monitor_modal_invocation:
+            # The second argument (index 1) is the db_result_id
+            if len(task_args) > 1 and task_args[1] == invocation_id:
+                return True
+    return False
+
+
 @router.post(
     "/blob-uploads",
 )
@@ -202,22 +224,23 @@ async def get_modal_invocation_output(
         response_data["error"] = inv.error
 
     elif inv.status is AsyncModalJobStatus.PENDING:
-        # invocation record still says pending -- rebuild the invocation and restart
-        # the background monitoring task in case it was dropped (e.g., server restart)
-        modal_fn = await ModalFunction.get(db, id=inv.function_id)
-        if modal_fn is not None:
-            # Rebuild the invocation object from the stored function_call_id
-            invocation = await _create_invocation_from_function_call_id(
-                inv.function_call_id, modal_client
-            )
-            # Start a new background monitoring task
-            background_tasks.add_task(
-                monitor_modal_invocation, invocation, inv.id, modal_client, settings
-            )
-            logger.info(
-                f"Restarted monitoring task for pending invocation {id} "
-                f"with function_call_id {inv.function_call_id}"
-            )
+        # invocation record still says pending -- check if there's already a background
+        # task monitoring it, and if not, rebuild the invocation and restart monitoring
+        if not _has_monitoring_task_for_invocation(background_tasks, inv.id):
+            modal_fn = await ModalFunction.get(db, id=inv.function_id)
+            if modal_fn is not None:
+                # Rebuild the invocation object from the stored function_call_id
+                invocation = await _create_invocation_from_function_call_id(
+                    inv.function_call_id, modal_client
+                )
+                # Start a new background monitoring task
+                background_tasks.add_task(
+                    monitor_modal_invocation, invocation, inv.id, modal_client, settings
+                )
+                logger.info(
+                    f"Restarted monitoring task for pending invocation {id} "
+                    f"with function_call_id {inv.function_call_id}"
+                )
 
     logger.info(response_data=response_data)
     return response_data

--- a/garden-backend-service/src/api/routes/modal/invocations.py
+++ b/garden-backend-service/src/api/routes/modal/invocations.py
@@ -161,8 +161,10 @@ async def invoke_modal_fn_async(
 @router.get("/{id}", response_model=ModalInvocationOutputsResponse)
 async def get_modal_invocation_output(
     id: int,
+    background_tasks: BackgroundTasks,
     modal_client: modal.Client = Depends(get_modal_client),
     db: AsyncSession = Depends(get_db_session),
+    settings: Settings = Depends(get_settings),
 ):
     inv = await ModalInvocationResult.get(db, id=id)
     if inv is None:
@@ -198,6 +200,24 @@ async def get_modal_invocation_output(
 
     elif inv.status in {AsyncModalJobStatus.ERROR, AsyncModalJobStatus.TIMED_OUT}:
         response_data["error"] = inv.error
+
+    elif inv.status is AsyncModalJobStatus.PENDING:
+        # invocation record still says pending -- rebuild the invocation and restart
+        # the background monitoring task in case it was dropped (e.g., server restart)
+        modal_fn = await ModalFunction.get(db, id=inv.function_id)
+        if modal_fn is not None:
+            # Rebuild the invocation object from the stored function_call_id
+            invocation = await _create_invocation_from_function_call_id(
+                inv.function_call_id, modal_client
+            )
+            # Start a new background monitoring task
+            background_tasks.add_task(
+                monitor_modal_invocation, invocation, inv.id, modal_client, settings
+            )
+            logger.info(
+                f"Restarted monitoring task for pending invocation {id} "
+                f"with function_call_id {inv.function_call_id}"
+            )
 
     logger.info(response_data=response_data)
     return response_data
@@ -237,6 +257,17 @@ async def _fetch_modal_function(
         )
         await resolver.load(obj)
         return obj
+
+
+async def _create_invocation_from_function_call_id(
+    function_call_id: str,
+    client: modal.Client,
+) -> modal._functions._Invocation:
+    """Rebuild an Invocation object from an existing function_call_id.
+
+    This is used to recreate dropped background monitoring tasks after server restarts.
+    """
+    return modal._functions._Invocation(client.stub, function_call_id, client)
 
 
 async def _create_invocation(

--- a/garden-backend-service/tests/api/routes/modal/test_invocations.py
+++ b/garden-backend-service/tests/api/routes/modal/test_invocations.py
@@ -582,6 +582,12 @@ async def test_get_modal_invocation_restarts_dropped_background_task(
         "src.api.routes.modal.invocations.monitor_modal_invocation"
     )
 
+    # Mock that no task exists (should restart)
+    mocker.patch(
+        "src.api.routes.modal.invocations._has_monitoring_task_for_invocation",
+        return_value=False,
+    )
+
     # Send the GET request for a pending invocation with no active background task
     response = await client.get("/modal-invocations/1")
     assert response.status_code == 200
@@ -596,3 +602,83 @@ async def test_get_modal_invocation_restarts_dropped_background_task(
 
     # Should have started a new background monitoring task
     mock_monitor.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_modal_invocation_does_not_restart_existing_background_task(
+    client,
+    mock_db_session,
+    override_get_settings_dependency,
+    override_get_modal_client_dependency,
+    mocker,
+):
+    """Test that we don't restart a background task if one is already running for the invocation."""
+    # Create mock modal function
+    mock_modal_fn = MagicMock()
+    mock_modal_fn.id = 1
+    mock_modal_fn.function_name = "test_function"
+    mock_modal_fn.modal_app = MagicMock()
+    mock_modal_fn.modal_app.app_name = "test_app"
+
+    # Create mock database objects for a pending invocation
+    mock_db_log = MagicMock()
+    mock_db_log.id = 1
+    mock_db_log.user_id = 1
+    mock_db_log.function_id = 1
+    mock_db_log.date_invoked = "2024-01-01T00:00:00"
+    mock_db_log.date_resolved = None
+
+    mock_db_result = MagicMock()
+    mock_db_result.id = 1
+    mock_db_result.function_id = 1
+    mock_db_result.function_call_id = "test_function_call_id"
+    mock_db_result.status = AsyncModalJobStatus.PENDING
+    mock_db_result.output = None
+    mock_db_result.error = None
+    mock_db_result.log = mock_db_log
+    mock_db_log.result = mock_db_result
+
+    # Mock the database queries
+    mocker.patch(
+        "src.api.routes.modal.invocations.ModalInvocationResult.get",
+        return_value=mock_db_result,
+    )
+    mocker.patch(
+        "src.api.routes.modal.invocations.ModalFunction.get",
+        return_value=mock_modal_fn,
+    )
+
+    # Mock the invocation reconstruction
+    mock_invocation = AsyncMock()
+    mock_invocation.function_call_id = "test_function_call_id"
+    mock_create_invocation = mocker.patch(
+        "src.api.routes.modal.invocations._create_invocation_from_function_call_id",
+        return_value=mock_invocation,
+    )
+
+    # Mock the background task monitoring
+    mock_monitor = mocker.patch(
+        "src.api.routes.modal.invocations.monitor_modal_invocation"
+    )
+
+    # Mock _has_monitoring_task_for_invocation to return True (task already exists)
+    mocker.patch(
+        "src.api.routes.modal.invocations._has_monitoring_task_for_invocation",
+        return_value=True,
+    )
+
+    # Send the GET request
+    response = await client.get("/modal-invocations/1")
+    assert response.status_code == 200
+    response_data = response.json()
+
+    # Should return pending status
+    assert response_data["id"] == 1
+    assert response_data["status"] == "pending"
+
+    # Should NOT have recreated the invocation
+    mock_create_invocation.assert_not_called()
+
+    # Should NOT have started a new background monitoring task
+    mock_monitor.assert_not_called()

--- a/garden-backend-service/tests/api/routes/modal/test_invocations.py
+++ b/garden-backend-service/tests/api/routes/modal/test_invocations.py
@@ -513,3 +513,86 @@ async def test_get_modal_invocation_output_with_blob_result(
     assert response_data["status"] == "done"
     assert "result" in response_data
     assert response_data["result"]["data_blob_url"] == "https://test-download-url"
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_get_modal_invocation_restarts_dropped_background_task(
+    client,
+    mock_db_session,
+    override_get_settings_dependency,
+    override_get_modal_client_dependency,
+    mocker,
+):
+    """Test that a dropped background task is restarted when fetching pending invocation."""
+    # Create mock modal function for rebuilding invocation
+    mock_modal_fn = MagicMock()
+    mock_modal_fn.id = 1
+    mock_modal_fn.function_name = "test_function"
+    mock_modal_fn.modal_app = MagicMock()
+    mock_modal_fn.modal_app.app_name = "test_app"
+
+    # Create mock database objects for a pending invocation
+    mock_db_log = MagicMock()
+    mock_db_log.id = 1
+    mock_db_log.user_id = 1
+    mock_db_log.function_id = 1
+    mock_db_log.date_invoked = "2024-01-01T00:00:00"
+    mock_db_log.date_resolved = None
+
+    mock_db_result = MagicMock()
+    mock_db_result.id = 1
+    mock_db_result.function_id = 1
+    mock_db_result.function_call_id = "test_function_call_id"
+    mock_db_result.status = AsyncModalJobStatus.PENDING  # Still pending
+    mock_db_result.output = None
+    mock_db_result.error = None
+    mock_db_result.log = mock_db_log
+    mock_db_log.result = mock_db_result
+
+    # Mock the database queries
+    mocker.patch(
+        "src.api.routes.modal.invocations.ModalInvocationResult.get",
+        return_value=mock_db_result,
+    )
+    mocker.patch(
+        "src.api.routes.modal.invocations.ModalFunction.get",
+        return_value=mock_modal_fn,
+    )
+
+    # Mock _fetch_modal_function and _create_invocation for rebuilding
+    mock_function = MagicMock()
+    mock_function.object_id = "mock_function_id"
+    mock_invocation = AsyncMock()
+    mock_invocation.function_call_id = "test_function_call_id"
+
+    mocker.patch(
+        "src.api.routes.modal.invocations._fetch_modal_function",
+        return_value=mock_function,
+    )
+
+    # Mock the invocation reconstruction - it should return an invocation with the same function_call_id
+    mock_create_invocation = mocker.patch(
+        "src.api.routes.modal.invocations._create_invocation_from_function_call_id",
+        return_value=mock_invocation,
+    )
+
+    # Mock the background task monitoring
+    mock_monitor = mocker.patch(
+        "src.api.routes.modal.invocations.monitor_modal_invocation"
+    )
+
+    # Send the GET request for a pending invocation with no active background task
+    response = await client.get("/modal-invocations/1")
+    assert response.status_code == 200
+    response_data = response.json()
+
+    # Should return pending status
+    assert response_data["id"] == 1
+    assert response_data["status"] == "pending"
+
+    # Should have recreated the invocation from the function_call_id
+    mock_create_invocation.assert_called_once()
+
+    # Should have started a new background monitoring task
+    mock_monitor.assert_called_once()


### PR DESCRIPTION
(hopefully) closes #381 
## Overview

unlike the issue description suggests, I think we should be able to just start a new background task when the `GET /modal-invocations/{id}` route is polled. 

This is the least-invasive option, but it's assuming (optimistically) that the `monitor_invocation` background task isn't the cause of the crashes. if it turns out that the `monitor_invocation` background task is the actual problem, we'll need to rethink how we interact with the modal backend in these routes. 

(I do think the culprit is probably a different background task -- maybe the auto delete gardens task -- since this one hasn't caused problems for us before and is very much load-bearing) 

## Testing

Unit tests (thanks claude) but actual manual testing still to be done against dev 