### PR TITLE
fix: allow stdlib imports from sub modules, reject relative imports

### DIFF
--- a/garden-backend-service/src/modal/user_file_parsing.py
+++ b/garden-backend-service/src/modal/user_file_parsing.py
@@ -81,28 +81,31 @@ class ModalFileParseResults:
     local_entrypoints: list[ModalLocalEntrypointInfo] = field(default_factory=list)
 
 
+def _is_allowed_import(module_name: str | None) -> bool:
+    """Check if the given module_name is 'modal' or a valid stdlib module."""
+    if not module_name:
+        return False
+    # Check if the top-level module is 'modal' or in stdlib
+    top_level_module = module_name.split(".")[0]
+    return top_level_module == "modal" or top_level_module in sys.stdlib_module_names
+
+
 def _validate_module_level_imports(tree: ast.Module) -> None:
     """Check that there are no module-level imports other than 'import modal' or stdlib imports."""
     for node in tree.body:
         match node:
             case ast.Import(names=names):
                 for alias in names:
-                    if (
-                        alias.name != "modal"
-                        and alias.name not in sys.stdlib_module_names
-                    ):
+                    if not _is_allowed_import(alias.name):
                         raise ModalException(
                             detail=f"Module-level import '{alias.name}' is not allowed.",
                             suggested_fix="Place all imports other than 'import modal' or stdlib imports inside function or class scopes.",
                         )
-            case ast.ImportFrom(module=module_name):
-                # Only allow if module_name is 'modal' or a valid stdlib module
-                if module_name is None or (
-                    module_name != "modal"
-                    and module_name not in sys.stdlib_module_names
-                ):
+            case ast.ImportFrom(module=module_name, level=level):
+                # level > 0 means relative import
+                if level > 0 or not _is_allowed_import(module_name):
                     raise ModalException(
-                        detail=f"Module-level import 'from {module_name}' is not allowed.",
+                        detail=f"Module-level import 'from {module_name if module_name else ''}' is not allowed.",
                         suggested_fix="Place all imports other than 'import modal' or stdlib imports inside function or class scopes.",
                     )
 

--- a/garden-backend-service/tests/api/routes/modal/test_user_file_parsing.py
+++ b/garden-backend-service/tests/api/routes/modal/test_user_file_parsing.py
@@ -153,3 +153,56 @@ def hello():
     assert "Module-level import 'definitelynotamodule' is not allowed" in str(
         excinfo.value.detail
     )
+
+
+def test_parse_modal_file_accepts_stdlib_submodule_import():
+    contents = """
+import urllib.request
+from urllib.request import Request
+import modal
+
+app = modal.App("my-app")
+
+@app.function()
+def hello():
+    return "Hello World"
+    """
+    # This should NOT raise ModalException
+    result = parse_modal_file(contents)
+    assert len(result.functions) == 1
+
+
+def test_parse_modal_file_rejects_nested_non_stdlib_import():
+    contents = """
+import requests.auth
+from requests.auth import HTTPBasicAuth
+import modal
+
+app = modal.App("my-app")
+
+@app.function()
+def hello():
+    return "Hello World"
+    """
+    with pytest.raises(ModalException) as excinfo:
+        parse_modal_file(contents)
+    assert "Module-level import 'requests.auth' is not allowed" in str(
+        excinfo.value.detail
+    )
+
+
+def test_parse_modal_file_rejects_relative_import():
+    contents = """
+from . import local_module
+from ..utils import helper
+import modal
+
+app = modal.App("my-app")
+
+@app.function()
+def hello():
+    return "Hello World"
+    """
+    with pytest.raises(ModalException) as excinfo:
+        parse_modal_file(contents)
+    assert "Module-level import 'from ' is not allowed" in str(excinfo.value.detail)


### PR DESCRIPTION
Resolves: #389 

## Overview

This PR tweaks the modal app validation logic to allow imports from stdlib sub-modules in the from of `import urllib.requests` and `from urllib.requests import ...`

I also added explicit checks to reject relative imports like `import .mymodule` and `from ..mymodule import ...`

## Testing

Some new unit tests!
