### PR TITLE
rearrange middleware so CORS is applied to all responses

### DIFF
--- a/garden-backend-service/src/main.py
+++ b/garden-backend-service/src/main.py
@@ -81,19 +81,19 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
+# Add middleware in reverse execution order (last added = first to execute)
+# CORSMiddleware must be outermost to ensure CORS headers are added to ALL responses,
+# including error responses from ErrorHandlingMiddleware
+app.add_middleware(ErrorHandlingMiddleware)
+app.add_middleware(ProcessTimeMiddleware)
+app.add_middleware(AddRequestIDMiddleware)
+app.add_middleware(HeaderLoggingMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-
-# Add our custom middleware
-app.add_middleware(ErrorHandlingMiddleware)
-app.add_middleware(ProcessTimeMiddleware)
-app.add_middleware(AddRequestIDMiddleware)
-app.add_middleware(HeaderLoggingMiddleware)
 
 app.include_router(greet.router)
 app.include_router(docker_push_token.router)


### PR DESCRIPTION
Follow up to #389 

## Overview

This PR fixes and issue I found testing yesterday's changes in staging:
<img width="1495" height="812" alt="image" src="https://github.com/user-attachments/assets/66e57b9d-a1b1-4933-af80-ad0ccded4709" />

Our nice error messages aren't accessible due to missing CORS headers. I think this is due to the order we are applying the middlewares:

  Before (broken):
  Request → HeaderLogging → RequestID → ProcessTime → ErrorHandling → CORS → Routes

Errors are bypassing the CORS middleware, so making sure we wrap the response with CORS headers first __should__ fix the issue.

  After (fixed, hopefully):
  Request → CORS → HeaderLogging → RequestID → ProcessTime → ErrorHandling → Routes

## Testing

Tough to test locally since my local setup doesn't send cross-origin requests. We will need to get this into dev to see if it works.
